### PR TITLE
Add phpredis tls support

### DIFF
--- a/src/Storage/Adapter/RedisResourceManager.php
+++ b/src/Storage/Adapter/RedisResourceManager.php
@@ -229,6 +229,10 @@ class RedisResourceManager
             throw new Exception\InvalidArgumentException('Missing required server host');
         }
 
+        if (isset($server['scheme']) && $server['scheme'] === 'tls') {
+            $host = 'tls://' . $host;
+        }
+
         $server = [
             'host'    => $host,
             'port'    => $port,


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
| BC Break      | no
| New Feature   | yes
| RFC           | no
| QA            | no

### Description

- Are you adding something the library currently does not support?
  - Why should it be added?
    phpredis supports tls since version 5.0
  - What will it enable?
    To use tls normalizeServer needs to support a scheme option.
  - How will the code be used?
    'options' => ['server' => 'tls://127.0.0.1:6380']