### PR TITLE
all datatypes for blackhole adapter

### DIFF
--- a/src/Storage/Adapter/BlackHole.php
+++ b/src/Storage/Adapter/BlackHole.php
@@ -355,7 +355,19 @@ class BlackHole implements
         if ($this->capabilities === null) {
             // use default capabilities only
             $this->capabilityMarker = new stdClass();
-            $this->capabilities     = new Capabilities($this, $this->capabilityMarker);
+            $this->capabilities     = new Capabilities($this, $this->capabilityMarker, [
+                'supportedDatatypes' => [
+                    'NULL'     => true,
+                    'boolean'  => true,
+                    'integer'  => true,
+                    'double'   => true,
+                    'string'   => true,
+                    'array'    => true,
+                    'object'   => true,
+                    'resource' => true,
+                    'light'    => true
+                ],
+            ]);
         }
         return $this->capabilities;
     }

--- a/test/Storage/Adapter/BlackHoleTest.php
+++ b/test/Storage/Adapter/BlackHoleTest.php
@@ -169,4 +169,14 @@ class BlackHoleTest extends TestCase
         $this->assertInstanceOf('Laminas\Cache\Storage\TotalSpaceCapableInterface', $this->storage);
         $this->assertSame(0, $this->storage->getTotalSpace());
     }
+
+    public function testSupportedDataTypes()
+    {
+        $capabilities = $this->storage->getCapabilities();
+        $supportedDataTypes = $capabilities->getSupportedDatatypes();
+        $this->assertNotEmpty($supportedDataTypes);
+        foreach ($supportedDataTypes as $supportedDataType) {
+            $this->assertTrue($supportedDataType);
+        }
+    }
 }


### PR DESCRIPTION
<!--
Fill in the relevant information below to help triage your issue.

Pick the target branch based on the following criteria:
  * Documentation improvement: master branch
  * Bugfix: master branch
  * QA improvement (additional tests, CS fixes, etc.) that does not change code
    behavior: master branch
  * New feature, or refactor of existing code: develop branch

You MUST provide a signoff in your commits for us to be able to accept your
patch; you can do this by providing either the --signoff or -s flag when using
"git commit". Please see the project contributing guide and
https://developercertificate.org for details.
-->

|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description

<!--
Tell us about why this change is necessary:
- Are you fixing a bug or providing a failing unit test to demonstrate a bug?
  - How do you reproduce it?
  - What did you expect to happen?
  - What actually happened?
  - TARGET THE master BRANCH

- Are you adding documentation?
  - TARGET THE master BRANCH

- Are you providing a QA improvement (additional tests, CS fixes, etc.) that
  does not change behavior?
  - Explain why the changes are necessary
  - TARGET THE master BRANCH

- Are you fixing a BC Break?
  - How do you reproduce it?
  - What was the previous behavior?
  - What is the current behavior?
  - TARGET THE master BRANCH

- Are you adding something the library currently does not support?
  - Why should it be added?
  - What will it enable?
  - How will the code be used?
  - TARGET THE develop BRANCH

- Are you refactoring code?
  - Why do you feel the refactor is necessary?
  - What types of refactoring are you doing?
  - TARGET THE develop BRANCH
-->

```PHP
...could not be created. Reason: The storage adapter "Zend\Cache\Storage\Adapter\BlackHole" requires a serializer plugin; please see https://docs.zendframework.com/zend-cache/storage/plugin/#quick-start for details on how to attach the plugin to your adapter.
```


```PHP
... could not be created. Reason: The adapter 'Zend\Cache\Storage\Adapter\BlackHole' doesn't implement 'Zend\EventManager\EventsCapableInterface' and therefore can't handle plugins
```

Blackhole adapter now accepts all datatypes and doesn't need a serializer anymore. Otherwise you have to implement the EventSystem but I don't think that's necessary because blackhole doesn't save anything anyway.