### PR TITLE
SimpleCacheDecorator does not fully conform with PSR-16 key length requirements

### DIFF
--- a/src/Psr/SimpleCache/SimpleCacheDecorator.php
+++ b/src/Psr/SimpleCache/SimpleCacheDecorator.php
@@ -347,10 +347,20 @@ class SimpleCacheDecorator implements SimpleCacheInterface
             ));
         }
 
-        if (preg_match('/^.{65,}/u', $key)) {
+        // get storage adapter capability value
+        $max_key_length = $this->storage->getCapabilities()->getMaxKeyLength();
+        
+        if ($max_key_length === -1) {
+            // default to <= 64 characters as per PSR-16
+            $max_key_length = 64;
+        }
+
+        //skip length check, if adapter capability reports unlimited key length
+        if ($max_key_length > 0 && preg_match('/^.{'.($max_key_length+1).',}/u', $key)) {
             throw new SimpleCacheInvalidArgumentException(sprintf(
-                'Invalid key "%s" provided; key is too long. Must be no more than 64 characters',
-                $key
+                'Invalid key "%s" provided; key is too long. Must be no more than %d characters',
+                $key,
+                $max_key_length
             ));
         }
     }

--- a/test/Psr/SimpleCache/SimpleCacheDecoratorTest.php
+++ b/test/Psr/SimpleCache/SimpleCacheDecoratorTest.php
@@ -72,13 +72,15 @@ class SimpleCacheDecoratorTest extends TestCase
     private function getMockCapabilities(
         array $supportedDataTypes = null,
         $staticTtl = true,
-        $minTtl = 60
+        $minTtl = 60,
+        $maxKeyLength = -1
     ) {
         $supportedDataTypes = $supportedDataTypes ?: $this->requiredTypes;
         $capabilities = $this->prophesize(Capabilities::class);
         $capabilities->getSupportedDatatypes()->willReturn($supportedDataTypes);
         $capabilities->getStaticTtl()->willReturn($staticTtl);
         $capabilities->getMinTtl()->willReturn($minTtl);
+        $capabilities->getMaxKeyLength()->willReturn($maxKeyLength);
 
         return $capabilities;
     }
@@ -91,9 +93,10 @@ class SimpleCacheDecoratorTest extends TestCase
         ObjectProphecy $storage,
         array $supportedDataTypes = null,
         $staticTtl = true,
-        $minTtl = 60
+        $minTtl = 60,
+        $maxKeyLength = -1
     ) {
-        $capabilities = $this->getMockCapabilities($supportedDataTypes, $staticTtl, $minTtl);
+        $capabilities = $this->getMockCapabilities($supportedDataTypes, $staticTtl, $minTtl, $maxKeyLength);
 
         $storage->getCapabilities()->will([$capabilities, 'reveal']);
     }
@@ -337,6 +340,30 @@ class SimpleCacheDecoratorTest extends TestCase
         $this->expectException(SimpleCacheInvalidArgumentException::class);
         $this->expectExceptionMessage($expectedMessage);
         $this->cache->set($key, 'value');
+    }
+    
+    /**
+     * @depends testSetShouldRaisePsrInvalidArgumentExceptionForInvalidKeys
+     */
+    public function testSetShouldAcknowledgeStorageAdapterMaxKeyLengthWithPsrDecorator()
+    {
+        $key_valid_length = str_repeat('abcd', 17); // length 68
+        $key_invalid_length = str_repeat('abcd', 63); // length 252
+        
+        $storage = $this->prophesize(StorageInterface::class);
+        $storage->getOptions()->will([$this->options, 'reveal']);
+        $this->mockCapabilities($storage, null, false, 60, 251);
+        $storage->setItem($key_valid_length, 'value')->shouldBeCalledTimes(1)->willReturn(true);
+        $storage->setItem($key_invalid_length, 'value')->shouldNotBeCalled();
+
+        $cache = new SimpleCacheDecorator($storage->reveal());
+
+        $this->assertTrue($cache->set($key_valid_length, 'value'));
+        
+        $this->expectException(SimpleCacheInvalidArgumentException::class);
+        $this->expectExceptionMessage('too long');
+        
+        $cache->set($key_invalid_length, 'value');
     }
 
     public function testSetShouldReRaiseExceptionThrownByStorage()


### PR DESCRIPTION
SimpleCacheDecorator does not fully conform with PSR-16 key length requirements. 

PSR-16 does not actually prohibit key lengths of more than 64 characters, if the underlying adapter allows it. 

This is causing issues with numerous 3rd party libraries that require PSR-16 cache, when using `laminas-cache`. 

Proposed solution is to acknowledge the value of `getMaxKeyLength()` from the storage adapter capabilities. 

If the adapter reports unknown max key length, the PSR-16 limit of 64 characters applies.

If the adapter reports unlimited key length, no length check is being performed.

Added unit test to confirm proper behavior.
