### PR TITLE
PHP 8 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,8 @@ env:
 
 matrix:
   fast_finish: true
+  allow_failures:
+    - php: nightly
   include:
     - php: 5.6
       env:
@@ -44,6 +46,18 @@ matrix:
       env:
         - DEPS=lowest
     - php: 7.3
+      env:
+        - DEPS=latest
+    - php: 7.4
+      env:
+        - DEPS=lowest
+    - php: 7.4
+      env:
+        - DEPS=latest
+    - php: nightly
+      env:
+        - DEPS=lowest
+    - php: nightly
       env:
         - DEPS=latest
 

--- a/composer.json
+++ b/composer.json
@@ -56,7 +56,7 @@
         "laminas/laminas-coding-standard": "~1.0.0",
         "laminas/laminas-serializer": "^2.6",
         "phpbench/phpbench": "^0.13",
-        "phpunit/phpunit": "^5.7.27 || ^6.5.8 || ^7.1.2"
+        "phpunit/phpunit": "^6.5.8 || ^7.1.2"
     },
     "provide": {
         "psr/cache-implementation": "1.0",

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         }
     },
     "require": {
-        "php": "^5.6 || ^7.0",
+        "php": "^5.6 || ^7.0 || ^8.0",
         "laminas/laminas-cache-storage-adapter-apc": "^1.0",
         "laminas/laminas-cache-storage-adapter-apcu": "^1.0",
         "laminas/laminas-cache-storage-adapter-blackhole": "^1.0",


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
| BC Break      | no
| New Feature   | yes
| RFC           | no
| QA            | yes

### Description

PHP 8 will be available soon and so it is time to verify that this component can be used on this new PHP version.
