### PR TITLE
feat: provide new `StorageAdapterFactory`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -55,6 +55,7 @@
         "cache/integration-tests": "^0.16",
         "laminas/laminas-coding-standard": "^2.1",
         "laminas/laminas-serializer": "^2.6",
+        "lctrs/psalm-psr-container-plugin": "^1.1",
         "phpbench/phpbench": "^0.17.1",
         "phpunit/phpunit": "^9.4",
         "psalm/plugin-phpunit": "^0.15.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d74555a3f20c7bb3eeee347fc0df9050",
+    "content-hash": "a103fa9df67259c252a9931576a7eb79",
     "packages": [
         {
             "name": "container-interop/container-interop",
@@ -2453,6 +2453,85 @@
                 "serializer"
             ],
             "time": "2019-12-31T17:42:11+00:00"
+        },
+        {
+            "name": "lctrs/psalm-psr-container-plugin",
+            "version": "1.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Lctrs/psalm-psr-container-plugin.git",
+                "reference": "a885e20d310225a53269d4322df9a0f3e58e6445"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Lctrs/psalm-psr-container-plugin/zipball/a885e20d310225a53269d4322df9a0f3e58e6445",
+                "reference": "a885e20d310225a53269d4322df9a0f3e58e6445",
+                "shasum": ""
+            },
+            "require": {
+                "ext-simplexml": "*",
+                "nikic/php-parser": "^4.10.2",
+                "php": "^7.3.0 || ^8.0.0",
+                "psr/container": "^1.0.0",
+                "vimeo/psalm": "^4.2.1"
+            },
+            "require-dev": {
+                "codeception/codeception": "^4.1.12",
+                "codeception/module-asserts": "^1.3.1",
+                "codeception/module-cli": "^1.1.0",
+                "codeception/module-filesystem": "^1.0.3",
+                "doctrine/coding-standard": "^8.2.0",
+                "ergebnis/composer-normalize": "^2.9.0",
+                "ergebnis/license": "^1.1.0",
+                "ergebnis/test-util": "^1.4.0",
+                "infection/infection": "^0.18.2",
+                "jangregor/phpstan-prophecy": "^0.8.1",
+                "phpspec/prophecy-phpunit": "^2.0.1",
+                "phpstan/extension-installer": "^1.0.5",
+                "phpstan/phpstan": "^0.12.57",
+                "phpstan/phpstan-deprecation-rules": "^0.12.5",
+                "phpstan/phpstan-phpunit": "^0.12.16",
+                "phpstan/phpstan-strict-rules": "^0.12.5",
+                "phpunit/phpunit": "^9.4.3",
+                "psalm/plugin-phpunit": "^0.13.0",
+                "symfony/yaml": "^5.1.8",
+                "thecodingmachine/safe": "^1.3.3",
+                "weirdan/codeception-psalm-module": "^0.12.0"
+            },
+            "type": "psalm-plugin",
+            "extra": {
+                "psalm": {
+                    "pluginClass": "Lctrs\\PsalmPsrContainerPlugin\\Plugin"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Lctrs\\PsalmPsrContainerPlugin\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jérôme Parmentier",
+                    "email": "jerome@prmntr.me"
+                }
+            ],
+            "description": "Let Psalm understand better psr11 containers",
+            "homepage": "https://github.com/Lctrs/psalm-psr-container-plugin",
+            "keywords": [
+                "code",
+                "container",
+                "inspection",
+                "php",
+                "psalm",
+                "psalm-plugin",
+                "psr",
+                "psr11"
+            ],
+            "time": "2020-11-27T21:54:19+00:00"
         },
         {
             "name": "lstrojny/functional-php",

--- a/psalm.xml
+++ b/psalm.xml
@@ -16,5 +16,6 @@
     </projectFiles>
     <plugins>
         <pluginClass class="Psalm\PhpUnitPlugin\Plugin"/>
+        <pluginClass class="Lctrs\PsalmPsrContainerPlugin\Plugin"/>
     </plugins>
 </psalm>

--- a/src/ConfigProvider.php
+++ b/src/ConfigProvider.php
@@ -8,6 +8,19 @@
 
 namespace Laminas\Cache;
 
+use Laminas\Cache\Service\PatternPluginManagerFactory;
+use Laminas\Cache\Service\StorageAdapterFactory;
+use Laminas\Cache\Service\StorageAdapterFactoryFactory;
+use Laminas\Cache\Service\StorageAdapterFactoryInterface;
+use Laminas\Cache\Service\StorageAdapterPluginManagerFactory;
+use Laminas\Cache\Service\StorageCacheAbstractServiceFactory;
+use Laminas\Cache\Service\StoragePluginFactory;
+use Laminas\Cache\Service\StoragePluginFactoryFactory;
+use Laminas\Cache\Service\StoragePluginFactoryInterface;
+use Laminas\Cache\Service\StoragePluginManagerFactory;
+use Laminas\Cache\Storage\AdapterPluginManager;
+use Laminas\Cache\Storage\PluginManager;
+
 class ConfigProvider
 {
     /**
@@ -31,12 +44,18 @@ class ConfigProvider
     {
         return [
             'abstract_factories' => [
-                Service\StorageCacheAbstractServiceFactory::class,
+                StorageCacheAbstractServiceFactory::class,
             ],
             'factories'          => [
-                PatternPluginManager::class         => Service\PatternPluginManagerFactory::class,
-                Storage\AdapterPluginManager::class => Service\StorageAdapterPluginManagerFactory::class,
-                Storage\PluginManager::class        => Service\StoragePluginManagerFactory::class,
+                PatternPluginManager::class  => PatternPluginManagerFactory::class,
+                AdapterPluginManager::class  => StorageAdapterPluginManagerFactory::class,
+                PluginManager::class         => StoragePluginManagerFactory::class,
+                StoragePluginFactory::class  => StoragePluginFactoryFactory::class,
+                StorageAdapterFactory::class => StorageAdapterFactoryFactory::class,
+            ],
+            'aliases'            => [
+                StoragePluginFactoryInterface::class  => StoragePluginFactory::class,
+                StorageAdapterFactoryInterface::class => StorageAdapterFactory::class,
             ],
         ];
     }

--- a/src/Service/StorageAdapterFactory.php
+++ b/src/Service/StorageAdapterFactory.php
@@ -1,0 +1,127 @@
+<?php
+
+/**
+ * @see       https://github.com/laminas/laminas-cache for the canonical source repository
+ * @copyright https://github.com/laminas/laminas-cache/blob/master/COPYRIGHT.md
+ * @license   https://github.com/laminas/laminas-cache/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace Laminas\Cache\Service;
+
+use InvalidArgumentException;
+use Laminas\Cache\Exception;
+use Laminas\Cache\Storage\AdapterPluginManager;
+use Laminas\Cache\Storage\PluginAwareInterface;
+use Laminas\Cache\Storage\StorageInterface;
+use Webmozart\Assert\Assert;
+
+use function assert;
+use function get_class;
+use function sprintf;
+
+/**
+ * @psalm-import-type PluginArrayConfigurationWithPriorityType from StorageAdapterFactoryInterface
+ */
+final class StorageAdapterFactory implements StorageAdapterFactoryInterface
+{
+    public const DEFAULT_PLUGIN_PRIORITY = 1;
+
+    /** @var AdapterPluginManager */
+    private $adapters;
+
+    /** @var StoragePluginFactoryInterface */
+    private $pluginFactory;
+
+    public function __construct(AdapterPluginManager $adapters, StoragePluginFactoryInterface $pluginFactory)
+    {
+        $this->adapters      = $adapters;
+        $this->pluginFactory = $pluginFactory;
+    }
+
+    public function createFromArrayConfiguration(array $configuration): StorageInterface
+    {
+        $adapterName    = $configuration['name'];
+        $adapterOptions = $configuration['options'] ?? [];
+        $plugins        = $configuration['plugins'] ?? [];
+
+        return $this->create($adapterName, $adapterOptions, $plugins);
+    }
+
+    public function create(string $storage, array $options = [], array $plugins = []): StorageInterface
+    {
+        $adapter = $this->adapters->build($storage, $options);
+        assert($adapter instanceof StorageInterface);
+
+        if ($plugins === []) {
+            return $adapter;
+        }
+
+        if (! $adapter instanceof PluginAwareInterface) {
+            throw new Exception\RuntimeException(sprintf(
+                "The adapter '%s' doesn't implement '%s' and therefore can't handle plugins",
+                get_class($adapter),
+                PluginAwareInterface::class
+            ));
+        }
+
+        foreach ($plugins as $pluginConfiguration) {
+            $plugin         = $this->pluginFactory->createFromArrayConfiguration($pluginConfiguration);
+            $pluginPriority = $pluginConfiguration['priority'] ?? self::DEFAULT_PLUGIN_PRIORITY;
+
+            if (! $adapter->hasPlugin($plugin)) {
+                $adapter->addPlugin($plugin, $pluginPriority);
+            }
+        }
+
+        return $adapter;
+    }
+
+    public function assertValidConfigurationStructure(array $configuration): void
+    {
+        try {
+            Assert::isNonEmptyMap($configuration, 'Configuration must be a non-empty array.');
+            Assert::keyExists($configuration, 'name', 'Configuration must contain a "name" key.');
+            Assert::stringNotEmpty($configuration['name'], 'Storage "name" has to be a non-empty string.');
+            Assert::nullOrIsMap(
+                $configuration['options'] ?? null,
+                'Storage "options" must be an array with string keys.'
+            );
+            if (isset($configuration['plugins'])) {
+                Assert::isList($configuration['plugins'], 'Storage "plugins" must be a list of plugin configurations.');
+                $this->assertValidPluginConfigurationStructure($configuration['name'], $configuration['plugins']);
+            }
+        } catch (InvalidArgumentException $exception) {
+            throw new Exception\InvalidArgumentException($exception->getMessage(), 0, $exception);
+        }
+    }
+
+    /**
+     * @psalm-param non-empty-string $adapter
+     * @psalm-param list<mixed> $plugins
+     * @psalm-assert list<PluginArrayConfigurationWithPriorityType> $plugins
+     */
+    private function assertValidPluginConfigurationStructure(string $adapter, array $plugins): void
+    {
+        Assert::allIsArray($plugins, 'All plugin configurations are expected to be an array.');
+        foreach ($plugins as $pluginConfiguration) {
+            try {
+                $this->pluginFactory->assertValidConfigurationStructure($pluginConfiguration);
+                if (isset($pluginConfiguration['priority'])) {
+                    Assert::integer($pluginConfiguration['priority'], 'Plugin priority has to be integer.');
+                }
+            } catch (Exception\InvalidArgumentException | InvalidArgumentException $exception) {
+                throw new Exception\InvalidArgumentException(
+                    sprintf(
+                        'Plugin configuration for adapter "%s" is invalid: %s',
+                        $adapter,
+                        $exception->getMessage()
+                    ),
+                    0,
+                    $exception
+                );
+            }
+        }
+    }
+}

--- a/src/Service/StorageAdapterFactoryFactory.php
+++ b/src/Service/StorageAdapterFactoryFactory.php
@@ -1,0 +1,25 @@
+<?php
+
+/**
+ * @see       https://github.com/laminas/laminas-cache for the canonical source repository
+ * @copyright https://github.com/laminas/laminas-cache/blob/master/COPYRIGHT.md
+ * @license   https://github.com/laminas/laminas-cache/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace Laminas\Cache\Service;
+
+use Laminas\Cache\Storage\AdapterPluginManager;
+use Psr\Container\ContainerInterface;
+
+final class StorageAdapterFactoryFactory
+{
+    public function __invoke(ContainerInterface $container): StorageAdapterFactory
+    {
+        return new StorageAdapterFactory(
+            $container->get(AdapterPluginManager::class),
+            $container->get(StoragePluginFactoryInterface::class)
+        );
+    }
+}

--- a/src/Service/StorageAdapterFactoryInterface.php
+++ b/src/Service/StorageAdapterFactoryInterface.php
@@ -1,0 +1,47 @@
+<?php
+
+/**
+ * @see       https://github.com/laminas/laminas-cache for the canonical source repository
+ * @copyright https://github.com/laminas/laminas-cache/blob/master/COPYRIGHT.md
+ * @license   https://github.com/laminas/laminas-cache/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace Laminas\Cache\Service;
+
+use Laminas\Cache\Exception\InvalidArgumentException;
+use Laminas\Cache\Storage\StorageInterface;
+
+/**
+ * @psalm-type InternalOptionalPriorityConfigurationType = array{priority?:int}
+ * NOTE: have to re-declare this here until https://github.com/vimeo/psalm/issues/5148 is fixed.
+ * @psalm-type InternalPluginArrayConfigurationType = array{name:non-empty-string,options?:array<string,mixed>}
+ * @psalm-type PluginArrayConfigurationWithPriorityType = InternalPluginArrayConfigurationType&InternalOptionalPriorityConfigurationType
+ * @psalm-type StorageAdapterArrayConfigurationType = array{
+ *     name:non-empty-string,
+ *     options?:array<string,mixed>,
+ *     plugins?: list<PluginArrayConfigurationWithPriorityType>
+ * }
+ */
+interface StorageAdapterFactoryInterface
+{
+    /**
+     * @psalm-param StorageAdapterArrayConfigurationType $configuration
+     */
+    public function createFromArrayConfiguration(array $configuration): StorageInterface;
+
+    /**
+     * @psalm-param non-empty-string $storage
+     * @param array<string,mixed>  $options
+     * @psalm-param list<PluginArrayConfigurationWithPriorityType> $plugins
+     */
+    public function create(string $storage, array $options = [], array $plugins = []): StorageInterface;
+
+    /**
+     * @param array<mixed> $configuration
+     * @psalm-assert StorageAdapterArrayConfigurationType $configuration
+     * @throws InvalidArgumentException If the provided configuration is invalid.
+     */
+    public function assertValidConfigurationStructure(array $configuration): void;
+}

--- a/src/Service/StorageAdapterFactoryInterface.php
+++ b/src/Service/StorageAdapterFactoryInterface.php
@@ -17,7 +17,8 @@ use Laminas\Cache\Storage\StorageInterface;
  * @psalm-type InternalOptionalPriorityConfigurationType = array{priority?:int}
  * NOTE: have to re-declare this here until https://github.com/vimeo/psalm/issues/5148 is fixed.
  * @psalm-type InternalPluginArrayConfigurationType = array{name:non-empty-string,options?:array<string,mixed>}
- * @psalm-type PluginArrayConfigurationWithPriorityType = InternalPluginArrayConfigurationType&InternalOptionalPriorityConfigurationType
+ * @psalm-type PluginArrayConfigurationWithPriorityType =
+ *              InternalPluginArrayConfigurationType&InternalOptionalPriorityConfigurationType
  * @psalm-type StorageAdapterArrayConfigurationType = array{
  *     name:non-empty-string,
  *     options?:array<string,mixed>,

--- a/src/Service/StorageCacheFactory.php
+++ b/src/Service/StorageCacheFactory.php
@@ -9,21 +9,21 @@
 namespace Laminas\Cache\Service;
 
 use Laminas\Cache\Storage\StorageInterface;
-use Laminas\Cache\StorageFactory;
 use Psr\Container\ContainerInterface;
+use Webmozart\Assert\Assert;
 
-/**
- * Storage cache factory.
- */
 final class StorageCacheFactory
 {
-    use PluginManagerLookupTrait;
-
     public function __invoke(ContainerInterface $container): StorageInterface
     {
-        $this->prepareStorageFactory($container);
+        $factory = $container->get(StorageAdapterFactoryInterface::class);
 
-        $cacheConfig = $container->get('config')['cache'] ?? [];
-        return StorageFactory::factory($cacheConfig);
+        $config = $container->get('config');
+        Assert::isArrayAccessible($config);
+        $cacheConfig = $config['cache'] ?? [];
+        Assert::isMap($cacheConfig);
+        $factory->assertValidConfigurationStructure($cacheConfig);
+
+        return $factory->createFromArrayConfiguration($cacheConfig);
     }
 }

--- a/src/Service/StoragePluginFactory.php
+++ b/src/Service/StoragePluginFactory.php
@@ -1,0 +1,60 @@
+<?php
+
+/**
+ * @see       https://github.com/laminas/laminas-cache for the canonical source repository
+ * @copyright https://github.com/laminas/laminas-cache/blob/master/COPYRIGHT.md
+ * @license   https://github.com/laminas/laminas-cache/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace Laminas\Cache\Service;
+
+use InvalidArgumentException as PhpInvalidArgumentException;
+use Laminas\Cache\Exception\InvalidArgumentException;
+use Laminas\Cache\Storage\Plugin\PluginInterface;
+use Laminas\Cache\Storage\PluginManager;
+use Webmozart\Assert\Assert;
+
+use function assert;
+
+final class StoragePluginFactory implements StoragePluginFactoryInterface
+{
+    /** @var PluginManager */
+    private $plugins;
+
+    public function __construct(PluginManager $plugins)
+    {
+        $this->plugins = $plugins;
+    }
+
+    public function createFromArrayConfiguration(array $configuration): PluginInterface
+    {
+        $name    = $configuration['name'];
+        $options = $configuration['options'] ?? [];
+
+        return $this->create($name, $options);
+    }
+
+    public function create(string $plugin, array $options = []): PluginInterface
+    {
+        $instance = $this->plugins->build($plugin, $options);
+        assert($instance instanceof PluginInterface);
+        return $instance;
+    }
+
+    public function assertValidConfigurationStructure(array $configuration): void
+    {
+        try {
+            Assert::isNonEmptyMap($configuration, 'Configuration must be a non-empty array.');
+            Assert::keyExists($configuration, 'name', 'Configuration must contain a "name" key.');
+            Assert::stringNotEmpty($configuration['name'], 'Plugin "name" has to be a non-empty string.');
+            Assert::nullOrIsMap(
+                $configuration['options'] ?? null,
+                'Plugin "options" must be an array with string keys.'
+            );
+        } catch (PhpInvalidArgumentException $exception) {
+            throw new InvalidArgumentException($exception->getMessage(), 0, $exception);
+        }
+    }
+}

--- a/src/Service/StoragePluginFactoryFactory.php
+++ b/src/Service/StoragePluginFactoryFactory.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laminas\Cache\Service;
+
+use Laminas\Cache\Storage\PluginManager;
+use Psr\Container\ContainerInterface;
+
+final class StoragePluginFactoryFactory
+{
+    public function __invoke(ContainerInterface $container): StoragePluginFactory
+    {
+        return new StoragePluginFactory($container->get(PluginManager::class));
+    }
+}

--- a/src/Service/StoragePluginFactoryInterface.php
+++ b/src/Service/StoragePluginFactoryInterface.php
@@ -1,0 +1,39 @@
+<?php
+
+/**
+ * @see       https://github.com/laminas/laminas-cache for the canonical source repository
+ * @copyright https://github.com/laminas/laminas-cache/blob/master/COPYRIGHT.md
+ * @license   https://github.com/laminas/laminas-cache/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace Laminas\Cache\Service;
+
+use Laminas\Cache\Exception\InvalidArgumentException;
+use Laminas\Cache\Storage\Plugin\PluginInterface;
+
+/**
+ * @psalm-type PluginArrayConfigurationType = array{name:non-empty-string,options?:array<string,mixed>}
+ */
+interface StoragePluginFactoryInterface
+{
+    /**
+     * @psalm-param PluginArrayConfigurationType $configuration
+     */
+    public function createFromArrayConfiguration(array $configuration): PluginInterface;
+
+    /**
+     * @psalm-param non-empty-string $plugin
+     * @param array<string,mixed>  $options
+     * @psalm-param array<string,mixed> $options
+     */
+    public function create(string $plugin, array $options = []): PluginInterface;
+
+    /**
+     * @param array<mixed> $configuration
+     * @psalm-assert PluginArrayConfigurationType $configuration
+     * @throws InvalidArgumentException If the provided configuration is invalid.
+     */
+    public function assertValidConfigurationStructure(array $configuration): void;
+}

--- a/test/Service/StorageAdapterFactoryFactoryTest.php
+++ b/test/Service/StorageAdapterFactoryFactoryTest.php
@@ -1,0 +1,43 @@
+<?php
+
+/**
+ * @see       https://github.com/laminas/laminas-cache for the canonical source repository
+ * @copyright https://github.com/laminas/laminas-cache/blob/master/COPYRIGHT.md
+ * @license   https://github.com/laminas/laminas-cache/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace LaminasTest\Cache\Service;
+
+use Laminas\Cache\Service\StorageAdapterFactoryFactory;
+use Laminas\Cache\Service\StoragePluginFactoryInterface;
+use Laminas\Cache\Storage\AdapterPluginManager;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+
+final class StorageAdapterFactoryFactoryTest extends TestCase
+{
+    /** @var StorageAdapterFactoryFactory */
+    private $factory;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->factory = new StorageAdapterFactoryFactory();
+    }
+
+    public function testWillRetrieveDependenciesFromContainer(): void
+    {
+        $adapters      = $this->createMock(AdapterPluginManager::class);
+        $pluginFactory = $this->createMock(StoragePluginFactoryInterface::class);
+        $container     = $this->createMock(ContainerInterface::class);
+        $container
+            ->expects(self::exactly(2))
+            ->method('get')
+            ->withConsecutive([AdapterPluginManager::class], [StoragePluginFactoryInterface::class])
+            ->willReturnOnConsecutiveCalls($adapters, $pluginFactory);
+
+        ($this->factory)($container);
+    }
+}

--- a/test/Service/StorageAdapterFactoryTest.php
+++ b/test/Service/StorageAdapterFactoryTest.php
@@ -1,0 +1,269 @@
+<?php
+
+/**
+ * @see       https://github.com/laminas/laminas-cache for the canonical source repository
+ * @copyright https://github.com/laminas/laminas-cache/blob/master/COPYRIGHT.md
+ * @license   https://github.com/laminas/laminas-cache/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace LaminasTest\Cache\Service;
+
+use Generator;
+use Laminas\Cache\Exception\InvalidArgumentException;
+use Laminas\Cache\Exception\RuntimeException;
+use Laminas\Cache\Service\StorageAdapterFactory;
+use Laminas\Cache\Service\StorageAdapterFactoryInterface;
+use Laminas\Cache\Service\StoragePluginFactoryInterface;
+use Laminas\Cache\Storage\Adapter\AbstractAdapter;
+use Laminas\Cache\Storage\AdapterPluginManager;
+use Laminas\Cache\Storage\Plugin\PluginInterface;
+use Laminas\Cache\Storage\PluginAwareInterface;
+use Laminas\Cache\Storage\StorageInterface;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+use function count;
+use function sprintf;
+
+/**
+ * @see StorageAdapterFactoryInterface
+ *
+ * @psalm-import-type PluginArrayConfigurationWithPriorityType from StorageAdapterFactoryInterface
+ */
+final class StorageAdapterFactoryTest extends TestCase
+{
+    /** @var StorageAdapterFactory */
+    private $factory;
+
+    /** @var AdapterPluginManager&MockObject */
+    private $adapters;
+
+    /** @var StoragePluginFactoryInterface&MockObject */
+    private $plugins;
+
+    private function createPluginAwareInterfaceIsMissingExceptionMessage(): string
+    {
+        return sprintf(
+            '\'%s\' and therefore can\'t handle plugins',
+            PluginAwareInterface::class
+        );
+    }
+
+    /**
+     * @return Generator<non-empty-string,array{0:non-empty-string,1:array<string,mixed>}>
+     */
+    public function storageConfigurations(): Generator
+    {
+        yield 'Storage without options' => [
+            'Foo',
+            [],
+        ];
+
+        yield 'Storage with options' => [
+            'Foo',
+            ['ttl' => 1],
+        ];
+    }
+
+    /**
+     * @psalm-return Generator<non-empty-string,array{0:list<PluginArrayConfigurationWithPriorityType>}>
+     */
+    public function pluginConfigurations(): Generator
+    {
+        yield 'list of plugin configurations' => [
+            [
+                ['name' => 'Foo'],
+                ['name' => 'Bar'],
+                ['name' => 'Baz'],
+            ],
+        ];
+    }
+
+    /**
+     * @psalm-return Generator<non-empty-string,array{0:array<mixed>,1:non-empty-string}>
+     */
+    public function invalidConfigurations(): Generator
+    {
+        yield 'empty map' => [
+            [],
+            'Configuration must be a non-empty array',
+        ];
+
+        yield 'missing name' => [
+            ['options' => []],
+            'Configuration must contain a "name" key',
+        ];
+
+        yield 'empty name' => [
+            ['name' => ''],
+            'Storage "name" has to be a non-empty string',
+        ];
+
+        yield 'invalid options' => [
+            ['name' => 'foo', 'options' => 'bar'],
+            'Storage "options" must be an array with string keys',
+        ];
+
+        yield 'invalid plugin configuration' => [
+            ['name' => 'foo', 'plugins' => ['bar']],
+            'All plugin configurations are expected to be an array',
+        ];
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->adapters = $this->createMock(AdapterPluginManager::class);
+        $this->plugins  = $this->createMock(StoragePluginFactoryInterface::class);
+        $this->factory  = new StorageAdapterFactory($this->adapters, $this->plugins);
+    }
+
+    /**
+     * @psalm-param non-empty-string $adapterName
+     * @param array<string,mixed> $adapterConfiguration
+     * @dataProvider storageConfigurations
+     */
+    public function testWillCreateStorageFromArrayConfiguration(
+        string $adapterName,
+        array $adapterConfiguration
+    ): void {
+        $adapterMock = $this->createMock(AbstractAdapter::class);
+        $this->adapters
+            ->expects(self::once())
+            ->method('build')
+            ->with($adapterName, $adapterConfiguration)
+            ->willReturn($adapterMock);
+
+        $adapter = $this->factory->createFromArrayConfiguration([
+            'name'    => $adapterName,
+            'options' => $adapterConfiguration,
+        ]);
+
+        self::assertSame($adapterMock, $adapter);
+    }
+
+    /**
+     * @psalm-param list<PluginArrayConfigurationWithPriorityType> $plugins
+     * @dataProvider pluginConfigurations
+     */
+    public function testWillCreateAdapterAndAttachesPlugins(array $plugins): void
+    {
+        $adapterMock = $this->createMock(AbstractAdapter::class);
+        $adapterName = 'foo';
+        $this
+            ->adapters
+            ->method('build')
+            ->with($adapterName)
+            ->willReturn($adapterMock);
+
+        $plugin = $this->createMock(PluginInterface::class);
+
+        $consecutivePluginCreationArguments = $consecutivePluginAddArguments = [];
+        foreach ($plugins as $pluginConfiguration) {
+            $consecutivePluginCreationArguments[] = [$pluginConfiguration];
+            $priority                             = $pluginConfiguration['priority']
+                ?? StorageAdapterFactory::DEFAULT_PLUGIN_PRIORITY;
+            $consecutivePluginAddArguments[]      = [$plugin, $priority];
+        }
+
+        $pluginCount = count($plugins);
+
+        $this
+            ->plugins
+            ->expects(self::exactly($pluginCount))
+            ->method('createFromArrayConfiguration')
+            ->withConsecutive(...$consecutivePluginCreationArguments)
+            ->willReturn($plugin);
+
+        $adapterMock
+            ->expects(self::exactly($pluginCount))
+            ->method('hasPlugin')
+            ->with($plugin)
+            ->willReturn(false);
+
+        $adapterMock
+            ->expects(self::exactly($pluginCount))
+            ->method('addPlugin')
+            ->withConsecutive(...$consecutivePluginAddArguments);
+
+        $this->factory->create('foo', [], $plugins);
+    }
+
+    public function testThrowsExceptionWhenStorageIsNotPluginAwareButPluginsConfigurationIsProvided(): void
+    {
+        $storage = $this->createMock(StorageInterface::class);
+        $this->adapters
+            ->expects(self::once())
+            ->method('build')
+            ->willReturn($storage);
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage($this->createPluginAwareInterfaceIsMissingExceptionMessage());
+        $this->factory->create('foo', [], [['name' => 'bar']]);
+    }
+
+    /**
+     * @param array<mixed>  $invalidConfiguration
+     * @psalm-param non-empty-string $expectedExceptionMessage
+     * @dataProvider invalidConfigurations
+     */
+    public function testWillThrowInvalidArgumentExceptionWhenInvalidConfigurationsWherePassedToConfigurationAssertion(
+        array $invalidConfiguration,
+        string $expectedExceptionMessage
+    ): void {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage($expectedExceptionMessage);
+        $this->factory->assertValidConfigurationStructure($invalidConfiguration);
+    }
+
+    public function testThrowsExceptionWhenInvalidPluginConfigurationIsPassedToConfigurationAssertion(): void
+    {
+        $this->expectExceptionMessage(InvalidArgumentException::class);
+        $this->expectExceptionMessage(
+            'Plugin configuration for adapter "foo" is invalid: ERROR FROM PLUGIN CONFIGURATION ASSERTION'
+        );
+
+        $this->plugins
+            ->expects(self::once())
+            ->method('assertValidConfigurationStructure')
+            ->with(['name' => ''])
+            ->willThrowException(new InvalidArgumentException('ERROR FROM PLUGIN CONFIGURATION ASSERTION'));
+
+        $this->factory->assertValidConfigurationStructure([
+            'name'    => 'foo',
+            'plugins' => [
+                ['name' => ''],
+            ],
+        ]);
+    }
+
+    public function testWillThrowInvalidArgumentExceptionWhenPluginPriorityIsNotInteger(): void
+    {
+        $this->expectExceptionMessage(InvalidArgumentException::class);
+        $this->expectExceptionMessage(
+            'Plugin configuration for adapter "bar" is invalid: Plugin priority has to be integer'
+        );
+
+        $this->plugins
+            ->expects(self::once())
+            ->method('assertValidConfigurationStructure');
+
+        $this->factory->assertValidConfigurationStructure([
+            'name'    => 'bar',
+            'plugins' => [
+                ['name' => 'baz', 'priority' => true],
+            ],
+        ]);
+    }
+
+    public function testWillAssertProperConfiguration(): void
+    {
+        $this->expectNotToPerformAssertions();
+        $this->factory->assertValidConfigurationStructure([
+            'name'    => 'foo',
+            'options' => ['bar' => 'baz'],
+        ]);
+    }
+}

--- a/test/Service/StorageCacheFactoryTest.php
+++ b/test/Service/StorageCacheFactoryTest.php
@@ -8,152 +8,52 @@
 
 namespace LaminasTest\Cache\Service;
 
-use Interop\Container\ContainerInterface;
+use Laminas\Cache\Service\StorageAdapterFactoryInterface;
 use Laminas\Cache\Service\StorageCacheFactory;
-use Laminas\Cache\Storage\Adapter\AbstractAdapter;
-use Laminas\Cache\Storage\Adapter\Memory;
-use Laminas\Cache\Storage\AdapterPluginManager;
-use Laminas\Cache\Storage\Plugin\PluginInterface;
-use Laminas\Cache\Storage\PluginManager;
-use Laminas\Cache\StorageFactory;
-use Laminas\ServiceManager\Config;
-use Laminas\ServiceManager\ServiceManager;
+use Laminas\Cache\Storage\StorageInterface;
 use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
 
-use function get_class;
-
-/**
- * @covers \Laminas\Cache\Service\StorageCacheFactory
- */
-class StorageCacheFactoryTest extends TestCase
+final class StorageCacheFactoryTest extends TestCase
 {
-    /** @var ServiceManager */
-    protected $sm;
+    /** @var StorageCacheFactory */
+    private $factory;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
-        StorageFactory::resetAdapterPluginManager();
-        StorageFactory::resetPluginManager();
-        $config   = [
-            'services'  => [
-                'config' => [
-                    'cache' => [
-                        'adapter' => 'Memory',
-                        'plugins' => ['Serializer', 'ClearExpiredByFactor'],
-                    ],
-                ],
-            ],
-            'factories' => [
-                'CacheFactory' => StorageCacheFactory::class,
-            ],
+        parent::setUp();
+        $this->factory = new StorageCacheFactory();
+    }
+
+    public function testWillUseStorageAdapterFactoryToCreateAdapter(): void
+    {
+        $cacheConfig = [
+            'foo' => 'bar',
         ];
-        $this->sm = new ServiceManager();
-        (new Config($config))->configureServiceManager($this->sm);
-    }
 
-    public function tearDown(): void
-    {
-        StorageFactory::resetAdapterPluginManager();
-        StorageFactory::resetPluginManager();
-    }
-
-    public function testCreateServiceCache(): void
-    {
-        $cache = $this->sm->get('CacheFactory');
-        self::assertEquals(Memory::class, get_class($cache));
-    }
-
-    public function testSetsFactoryAdapterPluginManagerInstanceOnInvocation(): void
-    {
-        $adapter = $this->createMock(AbstractAdapter::class);
-        $adapter
-            ->expects(self::never())
-            ->method('setOptions');
-        $adapter
-            ->expects(self::never())
-            ->method('hasPlugin');
-        $adapter
-            ->expects(self::never())
-            ->method('addPlugin');
-
-        $adapterPluginManager = $this->createMock(AdapterPluginManager::class);
-        $adapterPluginManager
+        $adapterFactory = $this->createMock(StorageAdapterFactoryInterface::class);
+        $adapterFactory
             ->expects(self::once())
-            ->method('get')
-            ->with('Memory')
+            ->method('assertValidConfigurationStructure')
+            ->with($cacheConfig);
+
+        $adapter = $this->createMock(StorageInterface::class);
+
+        $adapterFactory
+            ->expects(self::once())
+            ->method('createFromArrayConfiguration')
+            ->with($cacheConfig)
             ->willReturn($adapter);
 
         $container = $this->createMock(ContainerInterface::class);
         $container
-            ->method('has')
-            ->withConsecutive([AdapterPluginManager::class], [PluginManager::class], ['config'])
-            ->willReturnOnConsecutiveCalls(true, false, true);
-
-        $container
             ->method('get')
-            ->withConsecutive([AdapterPluginManager::class], ['config'])
-            ->willReturnOnConsecutiveCalls($adapterPluginManager, [
-                'cache' => ['adapter' => 'Memory'],
-            ]);
+            ->withConsecutive([StorageAdapterFactoryInterface::class], ['config'])
+            ->willReturnOnConsecutiveCalls(
+                $adapterFactory,
+                ['cache' => $cacheConfig]
+            );
 
-        $factory = new StorageCacheFactory();
-        self::assertSame($adapter, $factory($container, 'Cache'));
-        self::assertSame($adapterPluginManager, StorageFactory::getAdapterPluginManager());
-    }
-
-    public function testSetsFactoryPluginManagerInstanceOnInvocation(): void
-    {
-        $plugin = $this->createMock(PluginInterface::class);
-        $plugin
-            ->expects(self::never())
-            ->method('setOptions');
-
-        $pluginManager = $this->createMock(PluginManager::class);
-        $pluginManager
-            ->method('get')
-            ->with('Serializer')
-            ->willReturn($plugin);
-
-        $adapter = $this->createMock(AbstractAdapter::class);
-        $adapter
-            ->expects(self::never())
-            ->method('setOptions');
-        $adapter
-            ->expects(self::once())
-            ->method('hasPlugin')
-            ->with($plugin)
-            ->willReturn(false);
-
-        $adapter
-            ->expects(self::once())
-            ->method('addPlugin')
-            ->with($plugin);
-
-        $adapterPluginManager = $this->createMock(AdapterPluginManager::class);
-        $adapterPluginManager
-            ->expects(self::once())
-            ->method('get')
-            ->with('Memory')
-            ->willReturn($adapter);
-
-        $container = $this->createMock(ContainerInterface::class);
-        $container
-            ->method('has')
-            ->withConsecutive([AdapterPluginManager::class], [PluginManager::class], ['config'])
-            ->willReturnOnConsecutiveCalls(true, true, true);
-
-        $container
-            ->method('get')
-            ->withConsecutive([AdapterPluginManager::class], [PluginManager::class], ['config'])
-            ->willReturnOnConsecutiveCalls($adapterPluginManager, $pluginManager, [
-                'cache' => [
-                    'adapter' => 'Memory',
-                    'plugins' => ['Serializer'],
-                ],
-            ]);
-
-        $factory = new StorageCacheFactory();
-        $factory($container, 'Cache');
-        self::assertSame($pluginManager, StorageFactory::getPluginManager());
+        self::assertSame($adapter, ($this->factory)($container));
     }
 }

--- a/test/Service/StoragePluginFactoryFactoryTest.php
+++ b/test/Service/StoragePluginFactoryFactoryTest.php
@@ -1,0 +1,41 @@
+<?php
+
+/**
+ * @see       https://github.com/laminas/laminas-cache for the canonical source repository
+ * @copyright https://github.com/laminas/laminas-cache/blob/master/COPYRIGHT.md
+ * @license   https://github.com/laminas/laminas-cache/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace LaminasTest\Cache\Service;
+
+use Laminas\Cache\Service\StoragePluginFactoryFactory;
+use Laminas\Cache\Storage\PluginManager;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+
+final class StoragePluginFactoryFactoryTest extends TestCase
+{
+    /** @var StoragePluginFactoryFactory */
+    private $factory;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->factory = new StoragePluginFactoryFactory();
+    }
+
+    public function testWillRetrieveDependenciesFromContainer(): void
+    {
+        $plugins   = $this->createMock(PluginManager::class);
+        $container = $this->createMock(ContainerInterface::class);
+        $container
+            ->expects(self::once())
+            ->method('get')
+            ->with(PluginManager::class)
+            ->willReturn($plugins);
+
+        ($this->factory)($container);
+    }
+}

--- a/test/Service/StoragePluginFactoryTest.php
+++ b/test/Service/StoragePluginFactoryTest.php
@@ -1,0 +1,144 @@
+<?php
+
+/**
+ * @see       https://github.com/laminas/laminas-cache for the canonical source repository
+ * @copyright https://github.com/laminas/laminas-cache/blob/master/COPYRIGHT.md
+ * @license   https://github.com/laminas/laminas-cache/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace LaminasTest\Cache\Service;
+
+use Generator;
+use Laminas\Cache\Exception\InvalidArgumentException;
+use Laminas\Cache\Service\StoragePluginFactory;
+use Laminas\Cache\Storage\Plugin\PluginInterface;
+use Laminas\Cache\Storage\PluginManager;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+final class StoragePluginFactoryTest extends TestCase
+{
+    /** @var PluginManager&MockObject */
+    private $plugins;
+
+    /** @var StoragePluginFactory */
+    private $factory;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->plugins = $this->createMock(PluginManager::class);
+        $this->factory = new StoragePluginFactory($this->plugins);
+    }
+
+    /**
+     * @psalm-return Generator<non-empty-string,array{0:array<mixed>,1:non-empty-string}>
+     */
+    public function invalidConfigurations(): Generator
+    {
+        yield 'empty map' => [
+            [],
+            'Configuration must be a non-empty array',
+        ];
+
+        yield 'missing name' => [
+            ['options' => []],
+            'Configuration must contain a "name" key',
+        ];
+
+        yield 'empty name' => [
+            ['name' => ''],
+            'Plugin "name" has to be a non-empty string',
+        ];
+
+        yield 'invalid options' => [
+            ['name' => 'foo', 'options' => 'bar'],
+            'Plugin "options" must be an array with string keys',
+        ];
+    }
+
+    public function testWillCreatePluginFromArrayConfiguration(): void
+    {
+        $plugin = $this->createMock(PluginInterface::class);
+
+        $this->plugins
+            ->expects(self::once())
+            ->method('build')
+            ->with('foo')
+            ->willReturn($plugin);
+
+        $createdPlugin = $this->factory->createFromArrayConfiguration(['name' => 'foo']);
+        self::assertSame($plugin, $createdPlugin);
+    }
+
+    public function testWillCreatePluginFromArrayConfigurationWithOptions(): void
+    {
+        $plugin = $this->createMock(PluginInterface::class);
+
+        $this->plugins
+            ->expects(self::once())
+            ->method('build')
+            ->with('foo', ['bar' => 'baz'])
+            ->willReturn($plugin);
+
+        $createdPlugin = $this->factory->createFromArrayConfiguration(
+            ['name' => 'foo', 'options' => ['bar' => 'baz']]
+        );
+
+        self::assertSame($plugin, $createdPlugin);
+    }
+
+    public function testWillCreatePlugin(): void
+    {
+        $plugin = $this->createMock(PluginInterface::class);
+
+        $this->plugins
+            ->expects(self::once())
+            ->method('build')
+            ->with('foo')
+            ->willReturn($plugin);
+
+        $createdPlugin = $this->factory->create('foo');
+        self::assertSame($plugin, $createdPlugin);
+    }
+
+    public function testWillCreatePluginWithOptions(): void
+    {
+        $plugin = $this->createMock(PluginInterface::class);
+
+        $this->plugins
+            ->expects(self::once())
+            ->method('build')
+            ->with('foo', ['bar' => 'baz'])
+            ->willReturn($plugin);
+
+        $createdPlugin = $this->factory->create('foo', ['bar' => 'baz']);
+
+        self::assertSame($plugin, $createdPlugin);
+    }
+
+    /**
+     * @param array<mixed>  $invalidConfiguration
+     * @psalm-param non-empty-string $expectedExceptionMessage
+     * @dataProvider invalidConfigurations
+     */
+    public function testWillThrowInvalidArgumentExceptionWhenInvalidConfigurationIsPassedToConfigurationAssertion(
+        array $invalidConfiguration,
+        string $expectedExceptionMessage
+    ): void {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage($expectedExceptionMessage);
+        $this->factory->assertValidConfigurationStructure($invalidConfiguration);
+    }
+
+    public function testWillAssertProperConfiguration(): void
+    {
+        $this->expectNotToPerformAssertions();
+        $this->factory->assertValidConfigurationStructure([
+            'name'    => 'foo',
+            'options' => ['bar' => 'baz'],
+        ]);
+    }
+}


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation      | yes/no
| BC Break      | yes
| New Feature   | yes

### Description

Introducing `StorageAdapterFactory` to mark `StorageFactory` as deprecated.
Using the factory provides more flexibility as dependency injection for the `AdapterPluginManager` and the `PluginManager` is used instead of relying on globally available static properties.

This reduces complexity and provides better dependency injection support (if the `AdapterPluginManager` and/or the `PluginManager` is received from the container instead).

This addresses #3 
