### PR TITLE
qa: bring back unit test for `AdapterOptions`

### DIFF
--- a/test/Storage/Adapter/AdapterOptionsTest.php
+++ b/test/Storage/Adapter/AdapterOptionsTest.php
@@ -149,7 +149,7 @@ class AdapterOptionsTest extends TestCase
     public function testSetFromArrayWithPrioritizedOptions(): void
     {
         $options = new AdapterOptionsWithPrioritizedOptions();
-        
+
         // send unordered options array
         self::assertSame($options, $options->setFromArray([
             'nAmeSpace'   => 'foobar',

--- a/test/Storage/Adapter/AdapterOptionsTest.php
+++ b/test/Storage/Adapter/AdapterOptionsTest.php
@@ -1,0 +1,164 @@
+<?php
+
+/**
+ * @see       https://github.com/laminas/laminas-cache-storage-adapter-test for the canonical source repository
+ * @copyright https://github.com/laminas/laminas-cache-storage-adapter-test/blob/master/COPYRIGHT.md
+ * @license   https://github.com/laminas/laminas-cache-storage-adapter-test/blob/master/LICENSE.md New BSD License
+ */
+
+namespace LaminasTest\Cache\Storage\Adapter;
+
+use Laminas\Cache\Exception;
+use Laminas\Cache\Storage\Adapter\AbstractAdapter;
+use Laminas\Cache\Storage\Adapter\AdapterOptions;
+use Laminas\Cache\Storage\Event;
+use Laminas\Cache\Storage\StorageInterface;
+use LaminasTest\Cache\Storage\Adapter\TestAsset\AdapterOptionsWithPrioritizedOptions;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @group      Laminas_Cache
+ * @covers Laminas\Cache\Storage\Adapter\AdapterOptions<extended>
+ */
+class AdapterOptionsTest extends TestCase
+{
+    /**
+     * Mock of the storage
+     *
+     * @var StorageInterface
+     */
+    protected $storage;
+
+    /**
+     * Adapter options
+     *
+     * @var null|AdapterOptions
+     */
+    protected $options;
+
+    public function setUp(): void
+    {
+        $this->options = new AdapterOptions();
+    }
+
+    public function testKeyPattern(): void
+    {
+        // test default value
+        self::assertSame('', $this->options->getKeyPattern());
+
+        self::assertSame($this->options, $this->options->setKeyPattern('/./'));
+        self::assertSame('/./', $this->options->getKeyPattern());
+    }
+
+    public function testSetKeyPatternAllowEmptyString(): void
+    {
+        // first change to something different as an empty string is the default
+        $this->options->setKeyPattern('/.*/');
+
+        $this->options->setKeyPattern('');
+        self::assertSame('', $this->options->getKeyPattern());
+    }
+
+    public function testSetKeyPatternThrowsInvalidArgumentExceptionOnInvalidPattern(): void
+    {
+        $this->expectException(Exception\InvalidArgumentException::class);
+        $this->options->setKeyPattern('foo bar');
+    }
+
+    public function testNamespace(): void
+    {
+        self::assertSame($this->options, $this->options->setNamespace('foobar'));
+        self::assertSame('foobar', $this->options->getNamespace());
+    }
+
+    public function testReadable(): void
+    {
+        self::assertSame($this->options, $this->options->setReadable(false));
+        self::assertSame(false, $this->options->getReadable());
+
+        self::assertSame($this->options, $this->options->setReadable(true));
+        self::assertSame(true, $this->options->getReadable());
+    }
+
+    public function testWritable(): void
+    {
+        self::assertSame($this->options, $this->options->setWritable(false));
+        self::assertSame(false, $this->options->getWritable());
+
+        self::assertSame($this->options, $this->options->setWritable(true));
+        self::assertSame(true, $this->options->getWritable());
+    }
+
+    public function testTtl(): void
+    {
+        // infinite default value
+        self::assertSame(0, $this->options->getTtl());
+
+        self::assertSame($this->options, $this->options->setTtl(12345));
+        self::assertSame(12345, $this->options->getTtl());
+    }
+
+    public function testSetTtlThrowsInvalidArgumentExceptionOnNegativeValue(): void
+    {
+        $this->expectException(Exception\InvalidArgumentException::class);
+        $this->options->setTtl(-1);
+    }
+
+    public function testSetTtlAutoconvertToIntIfPossible(): void
+    {
+        $this->options->setTtl(12345.0);
+        self::assertSame(12345, $this->options->getTtl());
+
+        $this->options->setTtl(12345.678);
+        self::assertSame(12345.678, $this->options->getTtl());
+    }
+
+    public function testTriggerOptionEvent(): void
+    {
+        // setup an adapter implements EventsCapableInterface
+        $adapter = $this->getMockForAbstractClass(AbstractAdapter::class);
+        $this->options->setAdapter($adapter);
+
+        // setup event listener
+        $calledArgs = null;
+        $adapter->getEventManager()->attach('option', function () use (& $calledArgs) {
+            $calledArgs = func_get_args();
+        });
+
+        // trigger by changing an option
+        $this->options->setWritable(false);
+
+        // assert (hopefully) called listener and arguments
+        self::assertCount(1, $calledArgs, '"option" event was not triggered or got a wrong number of arguments');
+        /** @var Event|null $event */
+        $event = $calledArgs[0] ?? null;
+        self::assertInstanceOf(Event::class, $event);
+        self::assertEquals(['writable' => false], $event->getParams()->getArrayCopy());
+    }
+
+    public function testSetFromArrayWithoutPrioritizedOptions(): void
+    {
+        self::assertSame($this->options, $this->options->setFromArray([
+            'kEy_pattERN' => '/./',
+            'nameSPACE'   => 'foobar',
+        ]));
+        self::assertSame('/./', $this->options->getKeyPattern());
+        self::assertSame('foobar', $this->options->getNamespace());
+    }
+
+    public function testSetFromArrayWithPrioritizedOptions(): void
+    {
+        $options = new AdapterOptionsWithPrioritizedOptions();
+        
+        // send unordered options array
+        self::assertSame($options, $options->setFromArray([
+            'nAmeSpace'   => 'foobar',
+            'WriTAble'    => false,
+            'KEY_paTTern' => '/./',
+        ]));
+
+        self::assertEquals('foobar', $options->getNamespace());
+        self::assertFalse($options->getWritable());
+        self::assertEquals('/./', $options->getKeyPattern());
+    }
+}

--- a/test/Storage/Adapter/TestAsset/AdapterOptionsWithPrioritizedOptions.php
+++ b/test/Storage/Adapter/TestAsset/AdapterOptionsWithPrioritizedOptions.php
@@ -1,0 +1,14 @@
+<?php
+declare(strict_types=1);
+
+namespace LaminasTest\Cache\Storage\Adapter\TestAsset;
+
+use Laminas\Cache\Storage\Adapter\AdapterOptions;
+
+final class AdapterOptionsWithPrioritizedOptions extends AdapterOptions
+{
+    protected $__prioritizedProperties__ = [
+        'key_pattern',
+        'namespace',
+    ];
+}

--- a/test/Storage/Adapter/TestAsset/AdapterOptionsWithPrioritizedOptions.php
+++ b/test/Storage/Adapter/TestAsset/AdapterOptionsWithPrioritizedOptions.php
@@ -1,14 +1,22 @@
 <?php
 declare(strict_types=1);
 
+/**
+ * @see       https://github.com/laminas/laminas-cache-storage-adapter-test for the canonical source repository
+ * @copyright https://github.com/laminas/laminas-cache-storage-adapter-test/blob/master/COPYRIGHT.md
+ * @license   https://github.com/laminas/laminas-cache-storage-adapter-test/blob/master/LICENSE.md New BSD License
+ */
+
 namespace LaminasTest\Cache\Storage\Adapter\TestAsset;
 
 use Laminas\Cache\Storage\Adapter\AdapterOptions;
 
 final class AdapterOptionsWithPrioritizedOptions extends AdapterOptions
 {
+    // @codingStandardsIgnoreStart
     protected $__prioritizedProperties__ = [
         'key_pattern',
         'namespace',
     ];
+    // @codingStandardsIgnoreEnd
 }


### PR DESCRIPTION
<!--
Fill in the relevant information below to help triage your issue.

Pick the target branch based on the following criteria:
  * Documentation improvement: master branch
  * Bugfix: master branch
  * QA improvement (additional tests, CS fixes, etc.) that does not change code
    behavior: master branch
  * New feature, or refactor of existing code: develop branch

You MUST provide a signoff in your commits for us to be able to accept your
patch; you can do this by providing either the --signoff or -s flag when using
"git commit". Please see the project contributing guide and
https://developercertificate.org for details.
-->

|    Q          |   A
|-------------- | ------
| QA            | yes

### Description

With the creation of laminas-cache-storage-adapter-test, I've moved the AdapterOptions-Test due to a misunderstanding of what that test was for.
I'd like to bring it back to this repository where it belongs.
<!--
Tell us about why this change is necessary:
- Are you fixing a bug or providing a failing unit test to demonstrate a bug?
  - How do you reproduce it?
  - What did you expect to happen?
  - What actually happened?
  - TARGET THE master BRANCH

- Are you adding documentation?
  - TARGET THE master BRANCH

- Are you providing a QA improvement (additional tests, CS fixes, etc.) that
  does not change behavior?
  - Explain why the changes are necessary
  - TARGET THE master BRANCH

- Are you fixing a BC Break?
  - How do you reproduce it?
  - What was the previous behavior?
  - What is the current behavior?
  - TARGET THE master BRANCH

- Are you adding something the library currently does not support?
  - Why should it be added?
  - What will it enable?
  - How will the code be used?
  - TARGET THE develop BRANCH

- Are you refactoring code?
  - Why do you feel the refactor is necessary?
  - What types of refactoring are you doing?
  - TARGET THE develop BRANCH
-->
