### PR TITLE
qa: remove zendframework compatibility

### DIFF
--- a/src/ConfigProvider.php
+++ b/src/ConfigProvider.php
@@ -8,9 +8,6 @@
 
 namespace Laminas\Cache;
 
-use Zend\Cache\Storage\AdapterPluginManager;
-use Zend\Cache\Storage\PluginManager;
-
 class ConfigProvider
 {
     /**
@@ -33,12 +30,6 @@ class ConfigProvider
     public function getDependencyConfig()
     {
         return [
-            // Legacy Zend Framework aliases
-            'aliases'            => [
-                \Zend\Cache\PatternPluginManager::class => PatternPluginManager::class,
-                AdapterPluginManager::class             => Storage\AdapterPluginManager::class,
-                PluginManager::class                    => Storage\PluginManager::class,
-            ],
             'abstract_factories' => [
                 Service\StorageCacheAbstractServiceFactory::class,
             ],

--- a/src/PatternPluginManager.php
+++ b/src/PatternPluginManager.php
@@ -14,11 +14,6 @@ use Interop\Container\Exception\ContainerException;
 use Laminas\ServiceManager\AbstractPluginManager;
 use Laminas\ServiceManager\Factory\InvokableFactory;
 use Webmozart\Assert\Assert;
-use Zend\Cache\Pattern\CallbackCache;
-use Zend\Cache\Pattern\CaptureCache;
-use Zend\Cache\Pattern\ClassCache;
-use Zend\Cache\Pattern\ObjectCache;
-use Zend\Cache\Pattern\OutputCache;
 
 use function assert;
 
@@ -39,13 +34,6 @@ class PatternPluginManager extends AbstractPluginManager
         'Object'   => Pattern\ObjectCache::class,
         'output'   => Pattern\OutputCache::class,
         'Output'   => Pattern\OutputCache::class,
-
-        // Legacy Zend Framework aliases
-        CallbackCache::class => Pattern\CallbackCache::class,
-        CaptureCache::class  => Pattern\CaptureCache::class,
-        ClassCache::class    => Pattern\ClassCache::class,
-        ObjectCache::class   => Pattern\ObjectCache::class,
-        OutputCache::class   => Pattern\OutputCache::class,
     ];
 
     /** @var array<string,string> */

--- a/src/Storage/AdapterPluginManager.php
+++ b/src/Storage/AdapterPluginManager.php
@@ -10,22 +10,6 @@ namespace Laminas\Cache\Storage;
 
 use Laminas\ServiceManager\AbstractPluginManager;
 use Laminas\ServiceManager\Factory\InvokableFactory;
-use Zend\Cache\Storage\Adapter\Apc;
-use Zend\Cache\Storage\Adapter\Apcu;
-use Zend\Cache\Storage\Adapter\BlackHole;
-use Zend\Cache\Storage\Adapter\Dba;
-use Zend\Cache\Storage\Adapter\ExtMongoDb;
-use Zend\Cache\Storage\Adapter\Filesystem;
-use Zend\Cache\Storage\Adapter\Memcache;
-use Zend\Cache\Storage\Adapter\Memcached;
-use Zend\Cache\Storage\Adapter\Memory;
-use Zend\Cache\Storage\Adapter\MongoDb;
-use Zend\Cache\Storage\Adapter\Redis;
-use Zend\Cache\Storage\Adapter\Session;
-use Zend\Cache\Storage\Adapter\WinCache;
-use Zend\Cache\Storage\Adapter\XCache;
-use Zend\Cache\Storage\Adapter\ZendServerDisk;
-use Zend\Cache\Storage\Adapter\ZendServerShm;
 
 /**
  * Plugin manager implementation for cache storage adapters
@@ -94,24 +78,6 @@ class AdapterPluginManager extends AbstractPluginManager
         'zendServerSHM'    => Adapter\ZendServerShm::class,
         'ZendServerShm'    => Adapter\ZendServerShm::class,
         'ZendServerSHM'    => Adapter\ZendServerShm::class,
-
-        // Legacy Zend Framework aliases
-        Apc::class            => Adapter\Apc::class,
-        Apcu::class           => Adapter\Apcu::class,
-        BlackHole::class      => Adapter\BlackHole::class,
-        Dba::class            => Adapter\Dba::class,
-        ExtMongoDb::class     => Adapter\ExtMongoDb::class,
-        Filesystem::class     => Adapter\Filesystem::class,
-        Memcache::class       => Adapter\Memcache::class,
-        Memcached::class      => Adapter\Memcached::class,
-        Memory::class         => Adapter\Memory::class,
-        MongoDb::class        => Adapter\MongoDb::class,
-        Redis::class          => Adapter\Redis::class,
-        Session::class        => Adapter\Session::class,
-        WinCache::class       => Adapter\WinCache::class,
-        XCache::class         => Adapter\XCache::class,
-        ZendServerDisk::class => Adapter\ZendServerDisk::class,
-        ZendServerShm::class  => Adapter\ZendServerShm::class,
     ];
 
     /** @var array<string,string> */

--- a/src/Storage/PluginManager.php
+++ b/src/Storage/PluginManager.php
@@ -10,11 +10,6 @@ namespace Laminas\Cache\Storage;
 
 use Laminas\ServiceManager\AbstractPluginManager;
 use Laminas\ServiceManager\Factory\InvokableFactory;
-use Zend\Cache\Storage\Plugin\ClearExpiredByFactor;
-use Zend\Cache\Storage\Plugin\ExceptionHandler;
-use Zend\Cache\Storage\Plugin\IgnoreUserAbort;
-use Zend\Cache\Storage\Plugin\OptimizeByFactor;
-use Zend\Cache\Storage\Plugin\Serializer;
 
 /**
  * Plugin manager implementation for cache plugins
@@ -45,13 +40,6 @@ class PluginManager extends AbstractPluginManager
         'OptimizeByFactor'        => Plugin\OptimizeByFactor::class,
         'serializer'              => Plugin\Serializer::class,
         'Serializer'              => Plugin\Serializer::class,
-
-        // Legacy Zend Framework aliases
-        ClearExpiredByFactor::class => Plugin\ClearExpiredByFactor::class,
-        ExceptionHandler::class     => Plugin\ExceptionHandler::class,
-        IgnoreUserAbort::class      => Plugin\IgnoreUserAbort::class,
-        OptimizeByFactor::class     => Plugin\OptimizeByFactor::class,
-        Serializer::class           => Plugin\Serializer::class,
     ];
 
     /** @var array<string,string> */


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| QA            | yes

### Description

<!--
Tell us about why this change is necessary:
- Are you fixing a bug or providing a failing unit test to demonstrate a bug?
  - How do you reproduce it?
  - What did you expect to happen?
  - What actually happened?
  - TARGET THE master BRANCH

- Are you adding documentation?
  - TARGET THE master BRANCH

- Are you providing a QA improvement (additional tests, CS fixes, etc.) that
  does not change behavior?
  - Explain why the changes are necessary
  - TARGET THE master BRANCH

- Are you fixing a BC Break?
  - How do you reproduce it?
  - What was the previous behavior?
  - What is the current behavior?
  - TARGET THE master BRANCH

- Are you adding something the library currently does not support?
  - Why should it be added?
  - What will it enable?
  - How will the code be used?
  - TARGET THE develop BRANCH

- Are you refactoring code?
  - Why do you feel the refactor is necessary?
  - What types of refactoring are you doing?
  - TARGET THE develop BRANCH
-->

With #48, the `zendframework-bridge` was removed and thus, we can also remove the aliases

