### PR TITLE
docs: add example `composer.json` to v2.11

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,66 @@ storage adapters (DB, File, Memcache, etc).
 - File issues at https://github.com/laminas/laminas-cache/issues
 - Documentation is at https://docs.laminas.dev/laminas-cache/
 
+## Avoid unused cache adapters are being installed
+With `laminas-cache` v2.10.0, we introduced satellite packages for all cache adapters.
+
+In case, there is no need for several adapters in your project, you can use composer to ensure these adapters are not being installed. To make this happen, you have to specify a `replace` property within the `composer.json` of your project.
+
+### Example composer.json with only memory adapter being installed
+```json
+{
+    "name": "vendor/project",
+    "description": "",
+    "type": "project",
+    "require": {
+        "laminas/laminas-cache": "^2.10",
+        "laminas/laminas-cache-adapter-storage-memory": "^1.0"
+    },
+    "replace": {
+        "laminas/laminas-cache-storage-adapter-apc": "*",
+        "laminas/laminas-cache-storage-adapter-apcu": "*",
+        "laminas/laminas-cache-storage-adapter-blackhole": "*",
+        "laminas/laminas-cache-storage-adapter-dba": "*",
+        "laminas/laminas-cache-storage-adapter-ext-mongodb": "*",
+        "laminas/laminas-cache-storage-adapter-filesystem": "*",
+        "laminas/laminas-cache-storage-adapter-memcache": "*",
+        "laminas/laminas-cache-storage-adapter-memcached": "*",
+        "laminas/laminas-cache-storage-adapter-mongodb": "*",
+        "laminas/laminas-cache-storage-adapter-redis": "*",
+        "laminas/laminas-cache-storage-adapter-session": "*",
+        "laminas/laminas-cache-storage-adapter-wincache": "*",
+        "laminas/laminas-cache-storage-adapter-xcache": "*",
+        "laminas/laminas-cache-storage-adapter-zend-server": "*"
+    }
+}
+```
+
+> ### Only necessary in 2.10+
+> Starting with 3.0.0, no storage adapter is required by this component and thus, each project has to specify the storage adapters which are required by the project.
+> When migrated to 3.0.0, the `replace` section is not needed anymore.
+
+When using `composer install` on this, only the `laminas/laminas-cache-storage-adapter-memory` is being installed.
+
+```bash
+Loading composer repositories with package information
+Installing dependencies (including require-dev) from lock file
+Package operations: 10 installs, 0 updates, 0 removals
+  - Installing psr/simple-cache (1.0.1): Loading from cache
+  - Installing psr/cache (1.0.1): Loading from cache
+  - Installing laminas/laminas-zendframework-bridge (1.2.0): Loading from cache
+  - Installing laminas/laminas-stdlib (3.3.1): Loading from cache
+  - Installing psr/container (1.1.1): Loading from cache
+  - Installing container-interop/container-interop (1.2.0): Loading from cache
+  - Installing laminas/laminas-servicemanager (3.6.4): Loading from cache
+  - Installing laminas/laminas-eventmanager (3.3.1): Loading from cache
+  - Installing laminas/laminas-cache-storage-adapter-memory (1.0.1): Loading from cache
+  - Installing laminas/laminas-cache (2.10.1): Loading from cache
+Package container-interop/container-interop is abandoned, you should avoid using it. Use psr/container instead.
+Generating autoload files
+6 packages you are using are looking for funding.
+Use the `composer fund` command to find out more!
+```
+
 ## Benchmarks
 
 We provide scripts for benchmarking laminas-cache using the


### PR DESCRIPTION
<!--
Fill in the relevant information below to help triage your issue.

Pick the target branch based on the following criteria:
  * Documentation improvement: master branch
  * Bugfix: master branch
  * QA improvement (additional tests, CS fixes, etc.) that does not change code
    behavior: master branch
  * New feature, or refactor of existing code: develop branch

You MUST provide a signoff in your commits for us to be able to accept your
patch; you can do this by providing either the --signoff or -s flag when using
"git commit". Please see the project contributing guide and
https://developercertificate.org for details.
-->

|    Q          |   A
|-------------- | ------
| Documentation | yes

### Description

With this example, it is possible to only require those adapters which are required by the project.
Relates to #81 and is just rebased against 2.11.x to avoid a release of a new patch of 2.10.3 just to provide `README.md` content which is mostly read on github directly rather than within the `vendor` directory.
