### PR TITLE
bugfix: remove items returned true even when removal failed

### DIFF
--- a/src/Psr/CacheItemPool/CacheItemPoolDecorator.php
+++ b/src/Psr/CacheItemPool/CacheItemPoolDecorator.php
@@ -194,7 +194,7 @@ class CacheItemPoolDecorator implements CacheItemPoolInterface
         $this->deferred = array_diff_key($this->deferred, array_flip($keys));
 
         try {
-            return null !== $this->storage->removeItems($keys);
+            return $this->storage->removeItems($keys) === [];
         } catch (Exception\InvalidArgumentException $e) {
             throw new InvalidArgumentException($e->getMessage(), $e->getCode(), $e);
         } catch (Exception\ExceptionInterface $e) {

--- a/test/Psr/CacheItemPool/CacheItemPoolDecoratorTest.php
+++ b/test/Psr/CacheItemPool/CacheItemPoolDecoratorTest.php
@@ -388,7 +388,7 @@ class CacheItemPoolDecoratorTest extends TestCase
     public function testDeleteItemReturnsTrue()
     {
         $storage = $this->getStorageProphesy();
-        $storage->removeItems(['foo'])->shouldBeCalled()->willReturn(['foo']);
+        $storage->removeItems(['foo'])->shouldBeCalled()->willReturn([]);
 
         $this->assertTrue($this->getAdapter($storage)->deleteItem('foo'));
     }
@@ -433,7 +433,7 @@ class CacheItemPoolDecoratorTest extends TestCase
     public function testDeleteItemsReturnsTrue()
     {
         $storage = $this->getStorageProphesy();
-        $storage->removeItems(['foo', 'bar', 'baz'])->shouldBeCalled()->willReturn(['foo']);
+        $storage->removeItems(['foo', 'bar', 'baz'])->shouldBeCalled()->willReturn([]);
 
         $this->assertTrue($this->getAdapter($storage)->deleteItems(['foo', 'bar', 'baz']));
     }


### PR DESCRIPTION
<!--
Fill in the relevant information below to help triage your issue.

Pick the target branch based on the following criteria:
  * Documentation improvement: master branch
  * Bugfix: master branch
  * QA improvement (additional tests, CS fixes, etc.) that does not change code
    behavior: master branch
  * New feature, or refactor of existing code: develop branch

You MUST provide a signoff in your commits for us to be able to accept your
patch; you can do this by providing either the --signoff or -s flag when using
"git commit". Please see the project contributing guide and
https://developercertificate.org for details.
-->

|    Q          |   A
|-------------- | ------
| Bugfix        | yes

### Description

<!--
Tell us about why this change is necessary:
- Are you fixing a bug or providing a failing unit test to demonstrate a bug?
  - How do you reproduce it?
  - What did you expect to happen?
  - What actually happened?
  - TARGET THE master BRANCH

- Are you adding documentation?
  - TARGET THE master BRANCH

- Are you providing a QA improvement (additional tests, CS fixes, etc.) that
  does not change behavior?
  - Explain why the changes are necessary
  - TARGET THE master BRANCH

- Are you fixing a BC Break?
  - How do you reproduce it?
  - What was the previous behavior?
  - What is the current behavior?
  - TARGET THE master BRANCH

- Are you adding something the library currently does not support?
  - Why should it be added?
  - What will it enable?
  - How will the code be used?
  - TARGET THE develop BRANCH

- Are you refactoring code?
  - Why do you feel the refactor is necessary?
  - What types of refactoring are you doing?
  - TARGET THE develop BRANCH
-->

As per definition, `StorageInterface::removeItems` may return a non-empty array of keys which were not removed.
PHP Docblock for `StorageInterface::removeItems`: https://github.com/laminas/laminas-cache/blob/8b9991a31c25c2b7a142334ded74f3938b913337/src/Storage/StorageInterface.php#L194

The `CacheItemPoolDecorator` assumed that the deletion was successful even tho the storage said it was not (by return an array with a list of keys which could not be deleted.