### PR TITLE
bugfix: `CacheItemPoolDecorator` uses `StorageItemInterface::hasItems` to verify deletion

### DIFF
--- a/src/Psr/CacheItemPool/CacheItemPoolDecorator.php
+++ b/src/Psr/CacheItemPool/CacheItemPoolDecorator.php
@@ -15,6 +15,9 @@ use Laminas\Cache\Storage\FlushableInterface;
 use Laminas\Cache\Storage\StorageInterface;
 use Psr\Cache\CacheItemInterface;
 use Psr\Cache\CacheItemPoolInterface;
+use function array_unique;
+use function in_array;
+use function is_array;
 
 /**
  * Decorate laminas-cache adapters as PSR-6 cache item pools.
@@ -194,13 +197,25 @@ class CacheItemPoolDecorator implements CacheItemPoolInterface
         $this->deferred = array_diff_key($this->deferred, array_flip($keys));
 
         try {
-            return $this->storage->removeItems($keys) === [];
+            $result = $this->storage->removeItems($keys);
         } catch (Exception\InvalidArgumentException $e) {
             throw new InvalidArgumentException($e->getMessage(), $e->getCode(), $e);
         } catch (Exception\ExceptionInterface $e) {
+            return false;
         }
 
-        return false;
+        // BC compatibility can be removed in 3.0
+        if (! is_array($result)) {
+            return $result !== null;
+        }
+
+        if ($result === []) {
+            return true;
+        }
+
+        $existing = $this->storage->hasItems($result);
+        $unified = array_unique($existing);
+        return ! in_array(true, $unified, true);
     }
 
     /**

--- a/test/Psr/CacheItemPool/MockStorageTrait.php
+++ b/test/Psr/CacheItemPool/MockStorageTrait.php
@@ -73,6 +73,16 @@ trait MockStorageTrait
                 return $adapterOptions;
             });
 
+        $storage->hasItems(Argument::type('array'))
+            ->will(function ($args) use (&$items) {
+                $keys = $args[0];
+                $status = [];
+                foreach ($keys as $key) {
+                    $status[$key] = array_key_exists($key, $items);
+                }
+
+                return $status;
+            });
         $storage->hasItem(Argument::type('string'))
             ->will(function ($args) use (&$items) {
                 $key = $args[0];
@@ -118,7 +128,7 @@ trait MockStorageTrait
         $storage->removeItems(Argument::type('array'))
             ->will(function ($args) use (&$items) {
                 $items = array_diff_key($items, array_flip($args[0]));
-                return true;
+                return [];
             });
 
         return $storage;


### PR DESCRIPTION
<!--
Fill in the relevant information below to help triage your issue.

Pick the target branch based on the following criteria:
  * Documentation improvement: master branch
  * Bugfix: master branch
  * QA improvement (additional tests, CS fixes, etc.) that does not change code
    behavior: master branch
  * New feature, or refactor of existing code: develop branch

You MUST provide a signoff in your commits for us to be able to accept your
patch; you can do this by providing either the --signoff or -s flag when using
"git commit". Please see the project contributing guide and
https://developercertificate.org for details.
-->

|    Q          |   A
|-------------- | ------
| Bugfix        | yes

### Description

<!--
Tell us about why this change is necessary:
- Are you fixing a bug or providing a failing unit test to demonstrate a bug?
  - How do you reproduce it?
  - What did you expect to happen?
  - What actually happened?
  - TARGET THE master BRANCH

- Are you adding documentation?
  - TARGET THE master BRANCH

- Are you providing a QA improvement (additional tests, CS fixes, etc.) that
  does not change behavior?
  - Explain why the changes are necessary
  - TARGET THE master BRANCH

- Are you fixing a BC Break?
  - How do you reproduce it?
  - What was the previous behavior?
  - What is the current behavior?
  - TARGET THE master BRANCH

- Are you adding something the library currently does not support?
  - Why should it be added?
  - What will it enable?
  - How will the code be used?
  - TARGET THE develop BRANCH

- Are you refactoring code?
  - Why do you feel the refactor is necessary?
  - What types of refactoring are you doing?
  - TARGET THE develop BRANCH
-->

The decorator has to verify if the keys still exist when the underlying storage states the deletion was not successful. This fixes a possible regression in 2.10.2.

The `SimpleCacheDecorator` uses the same logic to verify if a deletion was successful in case keys were not deleted (due to the fact they've never existed).

Closes #99
