### PR TITLE
Normalize `StorageFactory` options

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -59,6 +59,9 @@
         "phpspec/prophecy-phpunit": "^2.0",
         "phpunit/phpunit": "^9.5"
     },
+    "conflict": {
+        "symfony/console": "<5.1"
+    },
     "provide": {
         "psr/cache-implementation": "1.0",
         "psr/simple-cache-implementation": "1.0"

--- a/composer.json
+++ b/composer.json
@@ -52,6 +52,7 @@
         "psr/simple-cache": "^1.0"
     },
     "require-dev": {
+        "laminas/laminas-cli": "^1.0",
         "laminas/laminas-coding-standard": "~1.0.0",
         "laminas/laminas-serializer": "^2.6",
         "phpbench/phpbench": "^1.0.0-beta2",
@@ -63,6 +64,7 @@
         "psr/simple-cache-implementation": "1.0"
     },
     "suggest": {
+        "laminas/laminas-cli": "The laminas-cli binary can be used to consume commands provided by this component",
         "laminas/laminas-serializer": "Laminas\\Serializer component"
     },
     "autoload": {

--- a/docs/book/psr16.md
+++ b/docs/book/psr16.md
@@ -19,10 +19,7 @@ use Laminas\Cache\StorageFactory;
 use Laminas\Cache\Psr\SimpleCache\SimpleCacheDecorator;
 
 $storage = StorageFactory::factory([
-    'adapter' => [
-        'name'    => 'apc',
-        'options' => [],
-    ],
+    'adapter' => 'apc',
 ]);
 
 $cache = new SimpleCacheDecorator($storage);
@@ -94,9 +91,7 @@ $cache->addPlugin(new Serializer());
 // Via configuration:
 $cache = StorageFactory::factory([
     'adapter' => 'filesystem',
-    'plugins' => [
-        'serializer',
-    ],
+    'plugins' => [['name' => 'serializer']],
 ]);
 ```
 

--- a/docs/book/psr6.md
+++ b/docs/book/psr6.md
@@ -21,10 +21,7 @@ use Laminas\Cache\StorageFactory;
 use Laminas\Cache\Psr\CacheItemPool\CacheItemPoolDecorator;
 
 $storage = StorageFactory::factory([
-    'adapter' => [
-        'name'    => 'apc',
-        'options' => [],
-    ],
+    'adapter' => 'apc',
 ]);
 
 $pool = new CacheItemPoolDecorator($storage);
@@ -108,13 +105,14 @@ $cacheLogger = function (\Exception $e) use ($logger) {
 };
                                 }
 $storage = StorageFactory::factory([
-    'adapter' => [
-        'name'    => 'apc',
-    ],
+    'adapter' => 'apc',
     'plugins' => [
-        'exceptionhandler' => [
-            'exception_callback' => $cacheLogger,
-            'throw_exceptions' => true,
+        [
+            'name' => 'exceptionhandler',
+            'options' => [
+                'exception_callback' => $cacheLogger,
+                'throw_exceptions' => true,
+            ],
         ],
     ],
 ]);

--- a/docs/book/storage/adapter.md
+++ b/docs/book/storage/adapter.md
@@ -31,12 +31,15 @@ use Laminas\Cache\StorageFactory;
 
 // Via factory:
 $cache = StorageFactory::factory([
-    'adapter' => [
-        'name'    => 'apc',
-        'options' => ['ttl' => 3600],
-    ],
+    'adapter' => 'apc',
+    'options' => ['ttl' => 3600],
     'plugins' => [
-        'exception_handler' => ['throw_exceptions' => false],
+        [
+            'name' => 'exception_handler',
+            'options' => [
+                'throw_exceptions' => false,
+             ], 
+        ],
     ],
 ]);
 
@@ -1074,13 +1077,14 @@ Capability | Value
 use Laminas\Cache\StorageFactory;
 
 $cache = StorageFactory::factory([
-    'adapter' => [
-        'name' => 'filesystem'
-    ],
+    'adapter' => 'filesystem',
     'plugins' => [
         // Don't throw exceptions on cache errors
-        'exception_handler' => [
-            'throw_exceptions' => false
+        [
+            'name' => 'exception_handler',
+            'options' => [
+                'throw_exceptions' => false
+            ],
         ],
     ],
 ]);
@@ -1100,21 +1104,24 @@ use Laminas\Cache\StorageFactory;
 
 // Instantiate the cache instance using a namespace for the same type of items
 $cache = StorageFactory::factory([
-    'adapter' => [
-        'name' => 'filesystem',
-        // With a namespace, we can indicate the same type of items,
+    'adapter' => 'filesystem',
+    // With a namespace, we can indicate the same type of items,
         // so we can simply use the database id as the cache key
-        'options' => [
-            'namespace' => 'dbtable',
-        ],
+    'options' => [
+        'namespace' => 'dbtable',
     ],
     'plugins' => [
         // Don't throw exceptions on cache errors
-        'exception_handler' => [
-            'throw_exceptions' => false,
+        [
+            'name' => 'exception_handler',
+            'options' => [
+                'throw_exceptions' => false,
+            ],
         ],
         // We store database rows on filesystem so we need to serialize them
-        'Serializer',
+        [
+            'name' => 'Serializer',
+        ],
     ],
 ]);
 

--- a/docs/book/storage/plugin.md
+++ b/docs/book/storage/plugin.md
@@ -25,7 +25,7 @@ use Laminas\Cache\StorageFactory;
 // All at once:
 $cache = StorageFactory::factory([
     'adapter' => 'filesystem',
-    'plugins' => ['serializer'],
+    'plugins' => [['name' => 'serializer']],
 ]);
 
 // Alternately, via discrete factory methods:

--- a/src/Command/DeprecatedStorageFactoryConfigurationCheckCommand.php
+++ b/src/Command/DeprecatedStorageFactoryConfigurationCheckCommand.php
@@ -1,0 +1,146 @@
+<?php
+/**
+ * @see       https://github.com/laminas/laminas-cache for the canonical source repository
+ * @copyright https://github.com/laminas/laminas-cache/blob/master/COPYRIGHT.md
+ * @license   https://github.com/laminas/laminas-cache/blob/master/LICENSE.md New BSD License
+ */
+declare(strict_types=1);
+
+namespace Laminas\Cache\Command;
+
+use ArrayAccess;
+use Laminas\Cache\Service\DeprecatedSchemaDetectorInterface;
+use Laminas\Cache\Service\StorageCacheAbstractServiceFactory;
+use Laminas\Cache\Service\StorageCacheFactory;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use function implode;
+
+/**
+ * @internal
+ */
+final class DeprecatedStorageFactoryConfigurationCheckCommand extends Command
+{
+    public const NAME = 'laminas-cache:deprecation:check-storage-factory-config';
+    private const DESCRIPTION = <<<EOT
+        Helps to detect deprecated cache configurations which are used to create the storage adapter.
+    EOT;
+
+    private const CACHES_CONFIGURATION_KEY = StorageCacheAbstractServiceFactory::CACHES_CONFIGURATION_KEY;
+    private const CACHE_CONFIGURATION_KEY = StorageCacheFactory::CACHE_CONFIGURATION_KEY;
+    private const MESSAGE_CACHE_CONFIGURATIONS_ARE_VALID
+        = '<info>The project configuration does not contain deprecated storage factory configurations.</info>';
+    private const MESSAGE_PROJECT_DOES_NOT_CONTAIN_CACHE_CONFIGURATIONS
+        = '<info>Project configuration does not contain deprecated configurations.';
+    private const MESSAGE_PROJECT_CONFIGURATION_CONTAINS_INVALID_CACHES_CONFIGURATION
+        = 'One or more configurations of the configured caches are deprecated.'
+        . ' Please normalize the `%s` configuration, it contains deprecated configuration(s)';
+    private const MESSAGE_PROJECT_CONFIGURATION_CONTAINS_INVALID_CACHE_CONFIGURATION
+        = 'Please normalize the `%s` configuration as it contains deprecated configuration.';
+    private const MESSAGE_SCHEMA_DOCUMENTATION_MESSAGE
+        = 'The normalized schema can be found at https://docs.laminas.dev/laminas-cache/storage/adapter/#quick-start';
+
+    protected static $defaultName = self::NAME;
+
+    /**
+     * @var ArrayAccess<string,mixed>
+     */
+    private $projectConfiguration;
+
+    /**
+     * @var DeprecatedSchemaDetectorInterface
+     */
+    private $deprecatedSchemaDetector;
+
+    public function __construct(
+        ArrayAccess $projectConfiguration,
+        DeprecatedSchemaDetectorInterface $deprecatedSchemaDetector
+    ) {
+        parent::__construct(self::NAME);
+        $this->projectConfiguration = $projectConfiguration;
+        $this->deprecatedSchemaDetector = $deprecatedSchemaDetector;
+    }
+
+    protected function configure(): void
+    {
+        $this
+            ->setDescription(self::DESCRIPTION);
+    }
+
+    public function run(InputInterface $input, OutputInterface $output): int
+    {
+        if (! $this->projectConfigurationContainsAnyCacheConfiguration()) {
+            $output->writeln(self::MESSAGE_PROJECT_DOES_NOT_CONTAIN_CACHE_CONFIGURATIONS);
+            return self::SUCCESS;
+        }
+
+        $output->writeln(
+            sprintf(
+                'Scanning `%s` configuration key for deprecated configurations...',
+                self::CACHES_CONFIGURATION_KEY
+            )
+        );
+        $caches = $this->projectConfiguration[self::CACHES_CONFIGURATION_KEY] ?? [];
+
+        $invalidCaches = [];
+        foreach ($caches as $cacheIdentifier => $configuration) {
+            if (! $this->deprecatedSchemaDetector->isDeprecatedStorageFactorySchema($configuration)) {
+                continue;
+            }
+            assert(is_string($cacheIdentifier));
+
+            $invalidCaches[] = $cacheIdentifier;
+        }
+
+        $cacheConfiguration = $this->projectConfiguration[self::CACHE_CONFIGURATION_KEY] ?? [];
+        $cacheConfigurationIsDeprecated = false;
+        if ($cacheConfiguration !== []) {
+            $cacheConfigurationIsDeprecated = $this->deprecatedSchemaDetector->isDeprecatedStorageFactorySchema(
+                $cacheConfiguration
+            );
+        }
+
+        if ($invalidCaches === [] && ! $cacheConfigurationIsDeprecated) {
+            $output->writeln(self::MESSAGE_CACHE_CONFIGURATIONS_ARE_VALID);
+            return self::SUCCESS;
+        }
+
+        if ($invalidCaches !== []) {
+            $output->writeln(
+                sprintf(
+                    '<error>%s: "%s".</error>',
+                    sprintf(
+                        self::MESSAGE_PROJECT_CONFIGURATION_CONTAINS_INVALID_CACHES_CONFIGURATION,
+                        self::CACHES_CONFIGURATION_KEY
+                    ),
+                    implode('", "', $invalidCaches)
+                )
+            );
+        }
+
+        if ($cacheConfigurationIsDeprecated) {
+            $output->writeln(
+                sprintf(
+                    '<error>%s</error>',
+                    sprintf(
+                        self::MESSAGE_PROJECT_CONFIGURATION_CONTAINS_INVALID_CACHE_CONFIGURATION,
+                        self::CACHE_CONFIGURATION_KEY
+                    )
+                )
+            );
+        }
+
+        $output->writeln(sprintf('<info>%s</info>', self::MESSAGE_SCHEMA_DOCUMENTATION_MESSAGE));
+
+        return self::FAILURE;
+    }
+
+    private function projectConfigurationContainsAnyCacheConfiguration(): bool
+    {
+        $cache = $this->projectConfiguration[self::CACHE_CONFIGURATION_KEY] ?? [];
+        $caches = $this->projectConfiguration[self::CACHES_CONFIGURATION_KEY] ?? [];
+
+        return $cache !== [] || $caches !== [];
+    }
+}

--- a/src/Command/DeprecatedStorageFactoryConfigurationCheckCommandFactory.php
+++ b/src/Command/DeprecatedStorageFactoryConfigurationCheckCommandFactory.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * @see       https://github.com/laminas/laminas-cache for the canonical source repository
+ * @copyright https://github.com/laminas/laminas-cache/blob/master/COPYRIGHT.md
+ * @license   https://github.com/laminas/laminas-cache/blob/master/LICENSE.md New BSD License
+ */
+declare(strict_types=1);
+
+namespace Laminas\Cache\Command;
+
+use ArrayAccess;
+use ArrayObject;
+use Laminas\Cache\Service\DeprecatedSchemaDetector;
+use Psr\Container\ContainerInterface;
+use RuntimeException;
+use function is_array;
+use function var_dump;
+
+/**
+ * @internal
+ */
+final class DeprecatedStorageFactoryConfigurationCheckCommandFactory
+{
+    public function __invoke(ContainerInterface $container): DeprecatedStorageFactoryConfigurationCheckCommand
+    {
+        $config = $container->get('config');
+        if (is_array($config)) {
+            $config = new ArrayObject($config);
+        }
+
+        if (! $config instanceof ArrayAccess) {
+            throw new RuntimeException('Configuration from container must be either `ArrayAccess` or an array.');
+        }
+
+        $schemaDetector = new DeprecatedSchemaDetector();
+        return new DeprecatedStorageFactoryConfigurationCheckCommand(
+            $config,
+            $schemaDetector
+        );
+    }
+}

--- a/src/ConfigProvider.php
+++ b/src/ConfigProvider.php
@@ -8,6 +8,9 @@
 
 namespace Laminas\Cache;
 
+use Laminas\Cache\Command\DeprecatedStorageFactoryConfigurationCheckCommand;
+use Laminas\Cache\Command\DeprecatedStorageFactoryConfigurationCheckCommandFactory;
+
 class ConfigProvider
 {
     /**
@@ -19,6 +22,7 @@ class ConfigProvider
     {
         return [
             'dependencies' => $this->getDependencyConfig(),
+            'laminas-cli' => $this->getCliConfig(),
         ];
     }
 
@@ -43,6 +47,21 @@ class ConfigProvider
                 PatternPluginManager::class => Service\PatternPluginManagerFactory::class,
                 Storage\AdapterPluginManager::class => Service\StorageAdapterPluginManagerFactory::class,
                 Storage\PluginManager::class => Service\StoragePluginManagerFactory::class,
+                DeprecatedStorageFactoryConfigurationCheckCommand::class =>
+                    DeprecatedStorageFactoryConfigurationCheckCommandFactory::class,
+            ],
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    public function getCliConfig(): array
+    {
+        return [
+            'commands' => [
+                DeprecatedStorageFactoryConfigurationCheckCommand::NAME =>
+                    DeprecatedStorageFactoryConfigurationCheckCommand::class,
             ],
         ];
     }

--- a/src/Module.php
+++ b/src/Module.php
@@ -20,6 +20,7 @@ class Module
         $provider = new ConfigProvider();
         return [
             'service_manager' => $provider->getDependencyConfig(),
+            'laminas-cli' => $provider->getCliConfig(),
         ];
     }
 }

--- a/src/Service/DeprecatedSchemaDetector.php
+++ b/src/Service/DeprecatedSchemaDetector.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * @see       https://github.com/laminas/laminas-cache for the canonical source repository
+ * @copyright https://github.com/laminas/laminas-cache/blob/master/COPYRIGHT.md
+ * @license   https://github.com/laminas/laminas-cache/blob/master/LICENSE.md New BSD License
+ */
+declare(strict_types=1);
+
+namespace Laminas\Cache\Service;
+
+/**
+ * @internal
+ */
+final class DeprecatedSchemaDetector implements DeprecatedSchemaDetectorInterface
+{
+
+    public function isDeprecatedStorageFactorySchema(array $configuration): bool
+    {
+        if (! is_string($configuration['adapter'])) {
+            return true;
+        }
+
+        if (! isset($configuration['plugins'])) {
+            return false;
+        }
+
+        if (! is_array($configuration['plugins'])) {
+            return true;
+        }
+
+        foreach ($configuration as $index => $plugin) {
+            if (! is_string($index) || ! is_array($plugin)) {
+                return true;
+            }
+
+            if (! isset($plugin['name'])) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/Service/DeprecatedSchemaDetectorInterface.php
+++ b/src/Service/DeprecatedSchemaDetectorInterface.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * @see       https://github.com/laminas/laminas-cache for the canonical source repository
+ * @copyright https://github.com/laminas/laminas-cache/blob/master/COPYRIGHT.md
+ * @license   https://github.com/laminas/laminas-cache/blob/master/LICENSE.md New BSD License
+ */
+declare(strict_types=1);
+
+namespace Laminas\Cache\Service;
+
+/**
+ * @internal
+ */
+interface DeprecatedSchemaDetectorInterface
+{
+    /**
+     * @param array<string,mixed> $configuration
+     */
+    public function isDeprecatedStorageFactorySchema(array $configuration): bool;
+}

--- a/src/Service/StorageCacheAbstractServiceFactory.php
+++ b/src/Service/StorageCacheAbstractServiceFactory.php
@@ -18,6 +18,7 @@ use Laminas\ServiceManager\ServiceLocatorInterface;
  */
 class StorageCacheAbstractServiceFactory implements AbstractFactoryInterface
 {
+    public const CACHES_CONFIGURATION_KEY = 'caches';
     use PluginManagerLookupTrait;
 
     /**
@@ -30,7 +31,7 @@ class StorageCacheAbstractServiceFactory implements AbstractFactoryInterface
      *
      * @var string
      */
-    protected $configKey = 'caches';
+    protected $configKey = self::CACHES_CONFIGURATION_KEY;
 
     /**
      * @param ContainerInterface $container

--- a/src/Service/StorageCacheFactory.php
+++ b/src/Service/StorageCacheFactory.php
@@ -19,6 +19,8 @@ use Laminas\ServiceManager\ServiceLocatorInterface;
  */
 class StorageCacheFactory implements FactoryInterface
 {
+    public const CACHE_CONFIGURATION_KEY = 'cache';
+
     use PluginManagerLookupTrait;
 
     public function __invoke(ContainerInterface $container, $requestedName, array $options = null)
@@ -26,7 +28,7 @@ class StorageCacheFactory implements FactoryInterface
         $this->prepareStorageFactory($container);
 
         $config = $container->get('config');
-        $cacheConfig = isset($config['cache']) ? $config['cache'] : [];
+        $cacheConfig = $config[self::CACHE_CONFIGURATION_KEY] ?? [];
         return StorageFactory::factory($cacheConfig);
     }
 

--- a/test/Command/DeprecatedStorageFactoryConfigurationCheckCommandTest.php
+++ b/test/Command/DeprecatedStorageFactoryConfigurationCheckCommandTest.php
@@ -1,0 +1,214 @@
+<?php
+/**
+ * @see       https://github.com/laminas/laminas-cache for the canonical source repository
+ * @copyright https://github.com/laminas/laminas-cache/blob/master/COPYRIGHT.md
+ * @license   https://github.com/laminas/laminas-cache/blob/master/LICENSE.md New BSD License
+ */
+declare(strict_types=1);
+
+namespace LaminasTest\Cache\Command;
+
+use ArrayObject;
+use Laminas\Cache\Command\DeprecatedStorageFactoryConfigurationCheckCommand;
+use Laminas\Cache\Service\DeprecatedSchemaDetectorInterface;
+use Laminas\Cache\Service\StorageCacheAbstractServiceFactory;
+use Laminas\Cache\Service\StorageCacheFactory;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+final class DeprecatedStorageFactoryConfigurationCheckCommandTest extends TestCase
+{
+    /**
+     * @var DeprecatedSchemaDetectorInterface&MockObject
+     */
+    private $detector;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->detector = $this->createMock(DeprecatedSchemaDetectorInterface::class);
+    }
+
+    public function testWillExitEarlyWhenProjectDoesNotHaveCacheConfigurations(): void
+    {
+        $config = new ArrayObject([]);
+        $command = new DeprecatedStorageFactoryConfigurationCheckCommand(
+            $config,
+            $this->detector
+        );
+
+        $input = $this->createMock(InputInterface::class);
+        $output = $this->createMock(OutputInterface::class);
+
+        self::assertEquals(Command::SUCCESS, $command->run($input, $output));
+    }
+
+    public function testWillExitEarlyWhenProjectContainsCacheConfigurationButItsEmpty(): void
+    {
+        $config = new ArrayObject([
+            StorageCacheFactory::CACHE_CONFIGURATION_KEY => [],
+        ]);
+        $command = new DeprecatedStorageFactoryConfigurationCheckCommand(
+            $config,
+            $this->detector
+        );
+
+        $input = $this->createMock(InputInterface::class);
+        $output = $this->createMock(OutputInterface::class);
+
+        self::assertEquals(Command::SUCCESS, $command->run($input, $output));
+    }
+
+    public function testWillExitEarlyWhenProjectContainsCachesConfigurationButItsEmpty(): void
+    {
+        $config = new ArrayObject([
+            StorageCacheAbstractServiceFactory::CACHES_CONFIGURATION_KEY => [],
+        ]);
+        $command = new DeprecatedStorageFactoryConfigurationCheckCommand(
+            $config,
+            $this->detector
+        );
+
+        $input = $this->createMock(InputInterface::class);
+        $output = $this->createMock(OutputInterface::class);
+
+        self::assertEquals(Command::SUCCESS, $command->run($input, $output));
+    }
+
+    public function testWillDetectInvalidCachesConfiguration(): void
+    {
+        $config = new ArrayObject([
+            StorageCacheAbstractServiceFactory::CACHES_CONFIGURATION_KEY => [
+                'foo' => [],
+            ],
+        ]);
+        $command = new DeprecatedStorageFactoryConfigurationCheckCommand(
+            $config,
+            $this->detector
+        );
+
+        $this->detector
+            ->expects(self::once())
+            ->method('isDeprecatedStorageFactorySchema')
+            ->with([])
+            ->willReturn(true);
+
+        $input = $this->createMock(InputInterface::class);
+        $output = $this->createMock(OutputInterface::class);
+
+        self::assertEquals(Command::FAILURE, $command->run($input, $output));
+    }
+
+    public function testWillDetectMultipleInvalidCachesConfiguration(): void
+    {
+        $config = new ArrayObject([
+            StorageCacheAbstractServiceFactory::CACHES_CONFIGURATION_KEY => [
+                'foo' => ['key' => 'foo'],
+                'bar' => ['key' => 'bar'],
+                'baz' => ['key' => 'baz'],
+            ],
+        ]);
+        $command = new DeprecatedStorageFactoryConfigurationCheckCommand(
+            $config,
+            $this->detector
+        );
+
+        $this->detector
+            ->expects(self::exactly(3))
+            ->method('isDeprecatedStorageFactorySchema')
+            ->withConsecutive([['key' => 'foo']], [['key' => 'bar']], [['key' => 'baz']])
+            ->willReturnOnConsecutiveCalls(true, false, true);
+
+        $input = $this->createMock(InputInterface::class);
+        $output = $this->createMock(OutputInterface::class);
+
+
+        $output
+            ->expects(self::exactly(2))
+            ->method('writeln')
+            ->withConsecutive([], [
+                self::callback(static function (string $message): bool {
+                    self::assertStringContainsString('Please normalize the `caches` configuration', $message);
+                    self::assertStringContainsString('"foo", "baz"', $message);
+                    return true;
+                })
+            ]);
+
+        self::assertEquals(Command::FAILURE, $command->run($input, $output));
+    }
+
+    public function testWillDetectInvalidCacheConfiguration(): void
+    {
+        $config = new ArrayObject([
+            StorageCacheFactory::CACHE_CONFIGURATION_KEY => [
+                'foo' => 'bar',
+            ],
+        ]);
+        $command = new DeprecatedStorageFactoryConfigurationCheckCommand(
+            $config,
+            $this->detector
+        );
+
+        $this->detector
+            ->expects(self::once())
+            ->method('isDeprecatedStorageFactorySchema')
+            ->with(['foo' => 'bar'])
+            ->willReturn(true);
+
+        $input = $this->createMock(InputInterface::class);
+        $output = $this->createMock(OutputInterface::class);
+        $output
+            ->expects(self::exactly(2))
+            ->method('writeln')
+            ->withConsecutive([], [
+                self::callback(static function (string $message): bool {
+                    self::assertStringContainsString('Please normalize the `cache` configuration', $message);
+                    return true;
+                })
+            ]);
+
+        self::assertEquals(Command::FAILURE, $command->run($input, $output));
+    }
+
+    public function testWontDetectNormalizedConfiguration(): void
+    {
+        $config = new ArrayObject([
+            StorageCacheFactory::CACHE_CONFIGURATION_KEY => [
+                'foo' => 'bar',
+            ],
+            StorageCacheAbstractServiceFactory::CACHES_CONFIGURATION_KEY => [
+                'foo' => ['bar' => 'baz'],
+            ],
+        ]);
+        $command = new DeprecatedStorageFactoryConfigurationCheckCommand(
+            $config,
+            $this->detector
+        );
+
+        $this->detector
+            ->expects(self::exactly(2))
+            ->method('isDeprecatedStorageFactorySchema')
+            ->withConsecutive([['bar' => 'baz']], [['foo' => 'bar']])
+            ->willReturn(false);
+
+        $input = $this->createMock(InputInterface::class);
+        $output = $this->createMock(OutputInterface::class);
+        $output
+            ->expects(self::exactly(2))
+            ->method('writeln')
+            ->withConsecutive([], [
+                self::callback(static function (string $message): bool {
+                    self::assertStringContainsString(
+                        'The project configuration does not contain deprecated',
+                        $message
+                    );
+                    return true;
+                })
+            ]);
+
+        self::assertEquals(Command::SUCCESS, $command->run($input, $output));
+    }
+}

--- a/test/Command/DeprecatedStorageFactoryConfigurationCheckCommandTest.php
+++ b/test/Command/DeprecatedStorageFactoryConfigurationCheckCommandTest.php
@@ -127,7 +127,7 @@ final class DeprecatedStorageFactoryConfigurationCheckCommandTest extends TestCa
 
 
         $output
-            ->expects(self::exactly(2))
+            ->expects(self::atLeast(2))
             ->method('writeln')
             ->withConsecutive([], [
                 self::callback(static function (string $message): bool {
@@ -161,7 +161,7 @@ final class DeprecatedStorageFactoryConfigurationCheckCommandTest extends TestCa
         $input = $this->createMock(InputInterface::class);
         $output = $this->createMock(OutputInterface::class);
         $output
-            ->expects(self::exactly(2))
+            ->expects(self::atLeast(2))
             ->method('writeln')
             ->withConsecutive([], [
                 self::callback(static function (string $message): bool {
@@ -197,7 +197,7 @@ final class DeprecatedStorageFactoryConfigurationCheckCommandTest extends TestCa
         $input = $this->createMock(InputInterface::class);
         $output = $this->createMock(OutputInterface::class);
         $output
-            ->expects(self::exactly(2))
+            ->expects(self::atLeast(2))
             ->method('writeln')
             ->withConsecutive([], [
                 self::callback(static function (string $message): bool {

--- a/test/Service/DeprecatedSchemaDetectorTest.php
+++ b/test/Service/DeprecatedSchemaDetectorTest.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * @see       https://github.com/laminas/laminas-cache for the canonical source repository
+ * @copyright https://github.com/laminas/laminas-cache/blob/master/COPYRIGHT.md
+ * @license   https://github.com/laminas/laminas-cache/blob/master/LICENSE.md New BSD License
+ */
+declare(strict_types=1);
+
+namespace LaminasTest\Cache\Service;
+
+use Generator;
+use Laminas\Cache\Service\DeprecatedSchemaDetector;
+use PHPUnit\Framework\TestCase;
+
+final class DeprecatedSchemaDetectorTest extends TestCase
+{
+    /**
+     * @var DeprecatedSchemaDetector
+     */
+    private $detector;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->detector = new DeprecatedSchemaDetector();
+    }
+
+    public function deprecatedStorageConfigurationSchemas(): Generator
+    {
+        yield 'adapter is not the alias or class-name of the adapter' => [
+            [
+                'adapter' => ['name' => 'adapterName'],
+            ],
+        ];
+
+        yield 'plugins contain plugin name as key and options as value' => [
+            [
+                'adapter' => 'adapterName',
+                'plugins' => ['pluginName' => ['option' => 'value']],
+            ],
+        ];
+
+        yield 'plugins are a list of plugin names' => [
+            [
+                'adapter' => 'adapterName',
+                'plugins' => ['pluginName'],
+            ],
+        ];
+    }
+
+    /**
+     * @param array<string,mixed> $schema
+     * @dataProvider deprecatedStorageConfigurationSchemas
+     */
+    public function testWillProperlyDetectAllInvalidConfigurationSchemas(array $schema): void
+    {
+        self::assertTrue($this->detector->isDeprecatedStorageFactorySchema($schema));
+    }
+}


### PR DESCRIPTION
<!--
Fill in the relevant information below to help triage your issue.

Pick the target branch based on the following criteria:
  * Documentation improvement: master branch
  * Bugfix: master branch
  * QA improvement (additional tests, CS fixes, etc.) that does not change code
    behavior: master branch
  * New feature, or refactor of existing code: develop branch

You MUST provide a signoff in your commits for us to be able to accept your
patch; you can do this by providing either the --signoff or -s flag when using
"git commit". Please see the project contributing guide and
https://developercertificate.org for details.
-->

|    Q          |   A
|-------------- | ------
| Documentation | yes
| QA            | yes

### Description

<!--
Tell us about why this change is necessary:
- Are you fixing a bug or providing a failing unit test to demonstrate a bug?
  - How do you reproduce it?
  - What did you expect to happen?
  - What actually happened?
  - TARGET THE master BRANCH

- Are you adding documentation?
  - TARGET THE master BRANCH

- Are you providing a QA improvement (additional tests, CS fixes, etc.) that
  does not change behavior?
  - Explain why the changes are necessary
  - TARGET THE master BRANCH

- Are you fixing a BC Break?
  - How do you reproduce it?
  - What was the previous behavior?
  - What is the current behavior?
  - TARGET THE master BRANCH

- Are you adding something the library currently does not support?
  - Why should it be added?
  - What will it enable?
  - How will the code be used?
  - TARGET THE develop BRANCH

- Are you refactoring code?
  - Why do you feel the refactor is necessary?
  - What types of refactoring are you doing?
  - TARGET THE develop BRANCH
-->

- with `laminas-cache` v3.0, the `StorageFactory` will be removed but actually, it allows plenty of different configuration schemas
- with `laminas-cache` v2.11.0, the `StorageFactory` was marked as deprecated and with #86, there will be an alternative
- the alternative from #86 only allows the normalized configuration



Fixes #87 