### PR TITLE
Set static variable to NULL

### DIFF
--- a/docs/book/pattern/class-cache.md
+++ b/docs/book/pattern/class-cache.md
@@ -124,7 +124,7 @@ class ClassCache extends CallbackCache
     public function __unset($name)
     {
         $class = $this->getOptions()->getClass();
-        unset($class::$name);
+        $class::$name = null;
     }
 }
 ```

--- a/src/Pattern/ClassCache.php
+++ b/src/Pattern/ClassCache.php
@@ -161,6 +161,6 @@ class ClassCache extends CallbackCache
     public function __unset($name)
     {
         $class = $this->getOptions()->getClass();
-        unset($class::$name);
+        $class::$name = null;
     }
 }


### PR DESCRIPTION
- resolves #107

This way the next time the function is called it will use `null` as the value for that `static::variable` as it was the last value of that `static::variable` before it was supposed  to have be `unset(static::variable);`.

