### PR TITLE
PSR-16 decorator should use maximum key length capability

### DIFF
--- a/src/Psr/SimpleCache/SimpleCacheDecorator.php
+++ b/src/Psr/SimpleCache/SimpleCacheDecorator.php
@@ -342,19 +342,19 @@ class SimpleCacheDecorator implements SimpleCacheInterface
         }
 
         // get storage adapter capability value
-        $max_key_length = $this->storage->getCapabilities()->getMaxKeyLength();
-        
-        if ($max_key_length === -1) {
+        $maximumKeyLength = $this->storage->getCapabilities()->getMaxKeyLength();
+
+        if ($maximumKeyLength === -1) {
             // default to <= 64 characters as per PSR-16
-            $max_key_length = 64;
+            $maximumKeyLength = 64;
         }
 
         //skip length check, if adapter capability reports unlimited key length
-        if ($max_key_length > 0 && preg_match('/^.{'.($max_key_length+1).',}/u', $key)) {
+        if ($maximumKeyLength > 0 && preg_match('/^.{'.($maximumKeyLength + 1).',}/u', $key)) {
             throw new SimpleCacheInvalidArgumentException(sprintf(
                 'Invalid key "%s" provided; key is too long. Must be no more than %d characters',
                 $key,
-                $max_key_length
+                $maximumKeyLength
             ));
         }
     }

--- a/src/Psr/SimpleCache/SimpleCacheDecorator.php
+++ b/src/Psr/SimpleCache/SimpleCacheDecorator.php
@@ -8,12 +8,15 @@ use DateTimeZone;
 use Exception;
 use Laminas\Cache\Exception\InvalidArgumentException as LaminasCacheInvalidArgumentException;
 use Laminas\Cache\Psr\SerializationTrait;
+use Laminas\Cache\Storage\Capabilities;
 use Laminas\Cache\Storage\ClearByNamespaceInterface;
 use Laminas\Cache\Storage\FlushableInterface;
 use Laminas\Cache\Storage\StorageInterface;
 use Psr\SimpleCache\CacheInterface as SimpleCacheInterface;
 use Throwable;
 use Traversable;
+use function get_class;
+use function sprintf;
 
 /**
  * Decorate a laminas-cache storage adapter for usage as a PSR-16 implementation.
@@ -50,6 +53,12 @@ class SimpleCacheDecorator implements SimpleCacheInterface
      */
     private $utc;
 
+    /**
+     * @var int
+     * @psalm-var 0|positive-int
+     */
+    private $maximumKeyLength;
+
     public function __construct(StorageInterface $storage)
     {
         if ($this->isSerializationRequired($storage)) {
@@ -61,7 +70,10 @@ class SimpleCacheDecorator implements SimpleCacheInterface
             ));
         }
 
-        $this->memoizeTtlCapabilities($storage);
+        $capabilities = $storage->getCapabilities();
+        $this->memoizeTtlCapabilities($capabilities);
+        $this->memoizeMaximumKeyLengthCapability($storage, $capabilities);
+
         $this->storage = $storage;
         $this->utc = new DateTimeZone('UTC');
     }
@@ -341,33 +353,22 @@ class SimpleCacheDecorator implements SimpleCacheInterface
             ));
         }
 
-        // get storage adapter capability value
-        $maximumKeyLength = $this->storage->getCapabilities()->getMaxKeyLength();
-
-        if ($maximumKeyLength === -1) {
-            // default to <= 64 characters as per PSR-16
-            $maximumKeyLength = 64;
-        }
-
-        //skip length check, if adapter capability reports unlimited key length
-        if ($maximumKeyLength > 0 && preg_match('/^.{'.($maximumKeyLength + 1).',}/u', $key)) {
+        if ($this->maximumKeyLength !== Capabilities::UNLIMITED_KEY_LENGTH
+            && preg_match('/^.{'.($this->maximumKeyLength + 1).',}/u', $key)
+        ) {
             throw new SimpleCacheInvalidArgumentException(sprintf(
                 'Invalid key "%s" provided; key is too long. Must be no more than %d characters',
                 $key,
-                $maximumKeyLength
+                $this->maximumKeyLength
             ));
         }
     }
 
     /**
      * Determine if the storage adapter provides per-item TTL capabilities
-     *
-     * @param StorageInterface $storage
-     * @return void
      */
-    private function memoizeTtlCapabilities(StorageInterface $storage)
+    private function memoizeTtlCapabilities(Capabilities $capabilities): void
     {
-        $capabilities = $storage->getCapabilities();
         $this->providesPerItemTtl = $capabilities->getStaticTtl() && (0 < $capabilities->getMinTtl());
     }
 
@@ -450,5 +451,30 @@ class SimpleCacheDecorator implements SimpleCacheInterface
             $array[$key] = $value;
         }
         return $array;
+    }
+
+    private function memoizeMaximumKeyLengthCapability(StorageInterface $storage, Capabilities $capabilities): void
+    {
+        $maximumKeyLength = $capabilities->getMaxKeyLength();
+
+        if ($maximumKeyLength === Capabilities::UNLIMITED_KEY_LENGTH) {
+            $this->maximumKeyLength = Capabilities::UNLIMITED_KEY_LENGTH;
+            return;
+        }
+
+        if ($maximumKeyLength === Capabilities::UNKNOWN_KEY_LENGTH) {
+            // For backward compatibility, assume adapters which do not provide a maximum key length do support 64 chars
+            $maximumKeyLength = 64;
+        }
+
+        if ($maximumKeyLength < 64) {
+            throw new SimpleCacheInvalidArgumentException(sprintf(
+                'The storage adapter "%s" does not fulfill the minimum requirements for PSR-16:'
+                .' The maximum key length capability must allow at least 64 characters.',
+                get_class($storage)
+            ));
+        }
+
+        $this->maximumKeyLength = $maximumKeyLength;
     }
 }

--- a/src/Psr/SimpleCache/SimpleCacheDecorator.php
+++ b/src/Psr/SimpleCache/SimpleCacheDecorator.php
@@ -341,10 +341,20 @@ class SimpleCacheDecorator implements SimpleCacheInterface
             ));
         }
 
-        if (preg_match('/^.{65,}/u', $key)) {
+        // get storage adapter capability value
+        $max_key_length = $this->storage->getCapabilities()->getMaxKeyLength();
+        
+        if ($max_key_length === -1) {
+            // default to <= 64 characters as per PSR-16
+            $max_key_length = 64;
+        }
+
+        //skip length check, if adapter capability reports unlimited key length
+        if ($max_key_length > 0 && preg_match('/^.{'.($max_key_length+1).',}/u', $key)) {
             throw new SimpleCacheInvalidArgumentException(sprintf(
-                'Invalid key "%s" provided; key is too long. Must be no more than 64 characters',
-                $key
+                'Invalid key "%s" provided; key is too long. Must be no more than %d characters',
+                $key,
+                $max_key_length
             ));
         }
     }

--- a/src/Storage/Capabilities.php
+++ b/src/Storage/Capabilities.php
@@ -9,6 +9,9 @@ use stdClass;
 
 class Capabilities
 {
+    public const UNKNOWN_KEY_LENGTH = -1;
+    public const UNLIMITED_KEY_LENGTH = 0;
+
     /**
      * The storage instance
      *
@@ -461,7 +464,7 @@ class Capabilities
      */
     public function getMaxKeyLength()
     {
-        return $this->getCapability('maxKeyLength', -1);
+        return $this->getCapability('maxKeyLength', self::UNKNOWN_KEY_LENGTH);
     }
 
     /**

--- a/test/Psr/SimpleCache/SimpleCacheDecoratorTest.php
+++ b/test/Psr/SimpleCache/SimpleCacheDecoratorTest.php
@@ -339,13 +339,10 @@ class SimpleCacheDecoratorTest extends TestCase
         $this->cache->set($key, 'value');
     }
     
-    /**
-     * @depends testSetShouldRaisePsrInvalidArgumentExceptionForInvalidKeys
-     */
     public function testSetShouldAcknowledgeStorageAdapterMaxKeyLengthWithPsrDecorator()
     {
-        $key_valid_length = str_repeat('abcd', 17); // length 68
-        $key_invalid_length = str_repeat('abcd', 63); // length 252
+        $key_valid_length = str_repeat('a', 68);
+        $key_invalid_length = str_repeat('b', 252);
         
         $storage = $this->prophesize(StorageInterface::class);
         $storage->getOptions()->will([$this->options, 'reveal']);

--- a/test/Psr/SimpleCache/SimpleCacheDecoratorTest.php
+++ b/test/Psr/SimpleCache/SimpleCacheDecoratorTest.php
@@ -338,12 +338,12 @@ class SimpleCacheDecoratorTest extends TestCase
         $this->expectExceptionMessage($expectedMessage);
         $this->cache->set($key, 'value');
     }
-    
+
     public function testSetShouldAcknowledgeStorageAdapterMaxKeyLengthWithPsrDecorator()
     {
         $key_valid_length = str_repeat('a', 68);
         $key_invalid_length = str_repeat('b', 252);
-        
+
         $storage = $this->prophesize(StorageInterface::class);
         $storage->getOptions()->will([$this->options, 'reveal']);
         $this->mockCapabilities($storage, null, false, 60, 251);
@@ -353,10 +353,10 @@ class SimpleCacheDecoratorTest extends TestCase
         $cache = new SimpleCacheDecorator($storage->reveal());
 
         $this->assertTrue($cache->set($key_valid_length, 'value'));
-        
+
         $this->expectException(SimpleCacheInvalidArgumentException::class);
         $this->expectExceptionMessage('too long');
-        
+
         $cache->set($key_invalid_length, 'value');
     }
 


### PR DESCRIPTION
<!--
Fill in the relevant information below to help triage your issue.

Pick the target branch based on the following criteria:
  * Documentation improvement: master branch
  * Bugfix: master branch
  * QA improvement (additional tests, CS fixes, etc.) that does not change code
    behavior: master branch
  * New feature, or refactor of existing code: develop branch

You MUST provide a signoff in your commits for us to be able to accept your
patch; you can do this by providing either the --signoff or -s flag when using
"git commit". Please see the project contributing guide and
https://developercertificate.org for details.
-->

|    Q          |   A
|-------------- | ------
| Bugfix        | yes
| BC Break      | no

### Description

Since its very first version, the `PSR-16` decorator only accepted keys up to 64 characters.
The user iganev provided a solution in #39 which based on the maximum key length capability of the storage adapters.

It seems that most of the storage adapters do return proper key lengths ([except redis](https://github.com/laminas/laminas-cache-storage-adapter-redis/issues/9)) and thus, this change seems absolutely legit to me.

So with v2.12.0 I'd introduce this change and with v3.0.0, all adapters returning `-1` as maximum key length will be incompatible with the `PSR-16` decorator.