### PR TITLE
Remove `\Exception` fallback for PSR-16 decorator

### DIFF
--- a/src/Psr/SimpleCache/SimpleCacheDecorator.php
+++ b/src/Psr/SimpleCache/SimpleCacheDecorator.php
@@ -5,7 +5,6 @@ namespace Laminas\Cache\Psr\SimpleCache;
 use DateInterval;
 use DateTimeImmutable;
 use DateTimeZone;
-use Exception;
 use Laminas\Cache\Exception\InvalidArgumentException as LaminasCacheInvalidArgumentException;
 use Laminas\Cache\Psr\SerializationTrait;
 use Laminas\Cache\Storage\Capabilities;
@@ -88,10 +87,8 @@ class SimpleCacheDecorator implements SimpleCacheInterface
         $this->success = null;
         try {
             $result = $this->storage->getItem($key, $this->success);
-        } catch (Throwable $e) {
-            throw static::translateException($e);
-        } catch (Exception $e) {
-            throw static::translateException($e);
+        } catch (Throwable $throwable) {
+            throw static::translateThrowable($throwable);
         }
 
         $result = $result === null ? $default : $result;
@@ -127,10 +124,8 @@ class SimpleCacheDecorator implements SimpleCacheInterface
 
         try {
             $result = $this->storage->setItem($key, $value);
-        } catch (Throwable $e) {
-            throw static::translateException($e);
-        } catch (Exception $e) {
-            throw static::translateException($e);
+        } catch (Throwable $throwable) {
+            throw static::translateThrowable($throwable);
         } finally {
             $options->setTtl($previousTtl);
         }
@@ -147,9 +142,7 @@ class SimpleCacheDecorator implements SimpleCacheInterface
 
         try {
             return null !== $this->storage->removeItem($key);
-        } catch (Throwable $e) {
-            return false;
-        } catch (Exception $e) {
+        } catch (Throwable $throwable) {
             return false;
         }
     }
@@ -182,10 +175,8 @@ class SimpleCacheDecorator implements SimpleCacheInterface
 
         try {
             $results = $this->storage->getItems($keys);
-        } catch (Throwable $e) {
-            throw static::translateException($e);
-        } catch (Exception $e) {
-            throw static::translateException($e);
+        } catch (Throwable $throwable) {
+            throw static::translateThrowable($throwable);
         }
 
         foreach ($keys as $key) {
@@ -230,10 +221,8 @@ class SimpleCacheDecorator implements SimpleCacheInterface
 
         try {
             $result = $this->storage->setItems($values);
-        } catch (Throwable $e) {
-            throw static::translateException($e);
-        } catch (Exception $e) {
-            throw static::translateException($e);
+        } catch (Throwable $throwable) {
+            throw static::translateThrowable($throwable);
         } finally {
             $options->setTtl($previousTtl);
         }
@@ -265,9 +254,7 @@ class SimpleCacheDecorator implements SimpleCacheInterface
 
         try {
             $result = $this->storage->removeItems($keys);
-        } catch (Throwable $e) {
-            return false;
-        } catch (Exception $e) {
+        } catch (Throwable $throwable) {
             return false;
         }
 
@@ -293,24 +280,18 @@ class SimpleCacheDecorator implements SimpleCacheInterface
 
         try {
             return $this->storage->hasItem($key);
-        } catch (Throwable $e) {
-            throw static::translateException($e);
-        } catch (Exception $e) {
-            throw static::translateException($e);
+        } catch (Throwable $throwable) {
+            throw static::translateThrowable($throwable);
         }
     }
 
-    /**
-     * @param Throwable|Exception $e
-     * @return SimpleCacheException
-     */
-    private static function translateException($e)
+    private static function translateThrowable(Throwable $throwable): SimpleCacheException
     {
-        $exceptionClass = $e instanceof LaminasCacheInvalidArgumentException
+        $exceptionClass = $throwable instanceof LaminasCacheInvalidArgumentException
             ? SimpleCacheInvalidArgumentException::class
             : SimpleCacheException::class;
 
-        return new $exceptionClass($e->getMessage(), $e->getCode(), $e);
+        return new $exceptionClass($throwable->getMessage(), $throwable->getCode(), $throwable);
     }
 
     /**


### PR DESCRIPTION
<!--
Fill in the relevant information below to help triage your issue.

Pick the target branch based on the following criteria:
  * Documentation improvement: master branch
  * Bugfix: master branch
  * QA improvement (additional tests, CS fixes, etc.) that does not change code
    behavior: master branch
  * New feature, or refactor of existing code: develop branch

You MUST provide a signoff in your commits for us to be able to accept your
patch; you can do this by providing either the --signoff or -s flag when using
"git commit". Please see the project contributing guide and
https://developercertificate.org for details.
-->

|    Q          |   A
|-------------- | ------
| QA            | yes

### Description

<!--
Tell us about why this change is necessary:
- Are you fixing a bug or providing a failing unit test to demonstrate a bug?
  - How do you reproduce it?
  - What did you expect to happen?
  - What actually happened?
  - TARGET THE master BRANCH

- Are you adding documentation?
  - TARGET THE master BRANCH

- Are you providing a QA improvement (additional tests, CS fixes, etc.) that
  does not change behavior?
  - Explain why the changes are necessary
  - TARGET THE master BRANCH

- Are you fixing a BC Break?
  - How do you reproduce it?
  - What was the previous behavior?
  - What is the current behavior?
  - TARGET THE master BRANCH

- Are you adding something the library currently does not support?
  - Why should it be added?
  - What will it enable?
  - How will the code be used?
  - TARGET THE develop BRANCH

- Are you refactoring code?
  - Why do you feel the refactor is necessary?
  - What types of refactoring are you doing?
  - TARGET THE develop BRANCH
-->

Remove deprecated `\Exception` catches which were introduced to handle exceptions pre PHP 7.0.