### PR TITLE
Deprecate anything related to pattern factories

### DIFF
--- a/src/Pattern/PatternCacheFactory.php
+++ b/src/Pattern/PatternCacheFactory.php
@@ -8,6 +8,10 @@ use Laminas\Cache\Exception\InvalidArgumentException;
 use Psr\Container\ContainerInterface;
 use function class_exists;
 
+/**
+ * @deprecated This will be removed with v3.0.0 as providing generic factories for cache patterns wont be suitable for
+ *             all possible combinations of implemented upstream patterns.
+ */
 final class PatternCacheFactory
 {
     /**

--- a/src/Pattern/StoragePatternCacheFactory.php
+++ b/src/Pattern/StoragePatternCacheFactory.php
@@ -12,6 +12,10 @@ use Psr\Container\ContainerInterface;
 use function class_exists;
 use function is_string;
 
+/**
+ * @deprecated This will be removed with v3.0.0 as providing generic factories for cache patterns wont be suitable for
+ *             all possible combinations of implemented upstream patterns.
+ */
 final class StoragePatternCacheFactory
 {
     /**

--- a/src/PatternFactory.php
+++ b/src/PatternFactory.php
@@ -7,8 +7,9 @@ use Laminas\Stdlib\ArrayUtils;
 use Traversable;
 
 /**
- * @deprecated Please do not use static factories anymore.
- *             Inject {@see PatternPluginManager} instead.
+ * @deprecated Please do not use static factories anymore. Please create your own instances by creating a
+ *             dedicated factory for each of the patterns with your project specific needs or just instantiate
+ *             the pattern manually instead of calling this factory.
  */
 abstract class PatternFactory
 {

--- a/src/PatternPluginManager/PatternPluginManagerTrait.php
+++ b/src/PatternPluginManager/PatternPluginManagerTrait.php
@@ -12,6 +12,8 @@ use Laminas\ServiceManager\Exception\InvalidServiceException;
  * Trait does not define properties, as the properties common between the
  * two versions are originally defined in their parent class, causing a
  * resolution conflict.
+ *
+ * @deprecated This will be removed in v3.0.0 and should never have been used in upstream projects anyways.
  */
 trait PatternPluginManagerTrait
 {

--- a/src/PatternPluginManager/PatternPluginManagerV2Polyfill.php
+++ b/src/PatternPluginManager/PatternPluginManagerV2Polyfill.php
@@ -12,6 +12,8 @@ use Laminas\ServiceManager\Factory\InvokableFactory;
  * Enforces that retrieved adapters are instances of
  * Pattern\PatternInterface. Additionally, it registers a number of default
  * patterns available.
+ * @deprecated This will be removed in v3.0.0. Cache pattern will require dependency injection and thus, a generic
+ *             plugin manager makes no sense anymore.
  */
 class PatternPluginManagerV2Polyfill extends AbstractPluginManager
 {

--- a/src/PatternPluginManager/PatternPluginManagerV3Polyfill.php
+++ b/src/PatternPluginManager/PatternPluginManagerV3Polyfill.php
@@ -12,6 +12,8 @@ use Laminas\ServiceManager\Factory\InvokableFactory;
  * Enforces that retrieved adapters are instances of
  * Pattern\PatternInterface. Additionally, it registers a number of default
  * patterns available.
+ * @deprecated This will be removed in v3.0.0. Cache pattern will require dependency injection and thus, a generic
+ *             plugin manager makes no sense anymore.
  */
 class PatternPluginManagerV3Polyfill extends AbstractPluginManager
 {


### PR DESCRIPTION
<!--
Fill in the relevant information below to help triage your issue.

Pick the target branch based on the following criteria:
  * Documentation improvement: master branch
  * Bugfix: master branch
  * QA improvement (additional tests, CS fixes, etc.) that does not change code
    behavior: master branch
  * New feature, or refactor of existing code: develop branch

You MUST provide a signoff in your commits for us to be able to accept your
patch; you can do this by providing either the --signoff or -s flag when using
"git commit". Please see the project contributing guide and
https://developercertificate.org for details.
-->

|    Q          |   A
|-------------- | ------
| QA            | yes

### Description

<!--
Tell us about why this change is necessary:
- Are you fixing a bug or providing a failing unit test to demonstrate a bug?
  - How do you reproduce it?
  - What did you expect to happen?
  - What actually happened?
  - TARGET THE master BRANCH

- Are you adding documentation?
  - TARGET THE master BRANCH

- Are you providing a QA improvement (additional tests, CS fixes, etc.) that
  does not change behavior?
  - Explain why the changes are necessary
  - TARGET THE master BRANCH

- Are you fixing a BC Break?
  - How do you reproduce it?
  - What was the previous behavior?
  - What is the current behavior?
  - TARGET THE master BRANCH

- Are you adding something the library currently does not support?
  - Why should it be added?
  - What will it enable?
  - How will the code be used?
  - TARGET THE develop BRANCH

- Are you refactoring code?
  - Why do you feel the refactor is necessary?
  - What types of refactoring are you doing?
  - TARGET THE develop BRANCH
-->

Pattern factories are quite complex depending on which pattern is used. There are pattern which do require a `StorageInterface` (which is the majority) and those, which don't.
Since there is that kind of complexity, upstream already had to write very specific configurations which can be replaced with dedicated factories in upstream projects.

With v2.12.0, we already changed our documentation on how cache pattern should be instantiated:
https://docs.laminas.dev/laminas-cache/pattern/intro/#quick-start

In v3.0.0, there won't be any way to dynamically create cache pattern via factories.