### PR TITLE
Replace `ServiceLocatorInterface` with `PluginManagerInterface` in `StorageAdapterFactory` and `StoragePluginFactory`

### DIFF
--- a/src/Service/StorageAdapterFactory.php
+++ b/src/Service/StorageAdapterFactory.php
@@ -8,7 +8,7 @@ use InvalidArgumentException;
 use Laminas\Cache\Exception;
 use Laminas\Cache\Storage\PluginAwareInterface;
 use Laminas\Cache\Storage\StorageInterface;
-use Laminas\ServiceManager\ServiceLocatorInterface;
+use Laminas\ServiceManager\PluginManagerInterface;
 use Webmozart\Assert\Assert;
 
 use function assert;
@@ -22,13 +22,13 @@ final class StorageAdapterFactory implements StorageAdapterFactoryInterface
 {
     public const DEFAULT_PLUGIN_PRIORITY = 1;
 
-    /** @var ServiceLocatorInterface */
+    /** @var PluginManagerInterface */
     private $adapters;
 
     /** @var StoragePluginFactoryInterface */
     private $pluginFactory;
 
-    public function __construct(ServiceLocatorInterface $adapters, StoragePluginFactoryInterface $pluginFactory)
+    public function __construct(PluginManagerInterface $adapters, StoragePluginFactoryInterface $pluginFactory)
     {
         $this->adapters      = $adapters;
         $this->pluginFactory = $pluginFactory;

--- a/src/Service/StoragePluginFactory.php
+++ b/src/Service/StoragePluginFactory.php
@@ -7,17 +7,17 @@ namespace Laminas\Cache\Service;
 use InvalidArgumentException as PhpInvalidArgumentException;
 use Laminas\Cache\Exception\InvalidArgumentException;
 use Laminas\Cache\Storage\Plugin\PluginInterface;
-use Laminas\ServiceManager\ServiceLocatorInterface;
+use Laminas\ServiceManager\PluginManagerInterface;
 use Webmozart\Assert\Assert;
 
 use function assert;
 
 final class StoragePluginFactory implements StoragePluginFactoryInterface
 {
-    /** @var ServiceLocatorInterface */
+    /** @var PluginManagerInterface */
     private $plugins;
 
-    public function __construct(ServiceLocatorInterface $plugins)
+    public function __construct(PluginManagerInterface $plugins)
     {
         $this->plugins = $plugins;
     }

--- a/test/Service/StorageAdapterFactoryFactoryTest.php
+++ b/test/Service/StorageAdapterFactoryFactoryTest.php
@@ -7,7 +7,7 @@ namespace LaminasTest\Cache\Service;
 use Laminas\Cache\Service\StorageAdapterFactoryFactory;
 use Laminas\Cache\Service\StoragePluginFactoryInterface;
 use Laminas\Cache\Storage\AdapterPluginManager;
-use Laminas\ServiceManager\ServiceLocatorInterface;
+use Laminas\ServiceManager\PluginManagerInterface;
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
 
@@ -24,7 +24,7 @@ final class StorageAdapterFactoryFactoryTest extends TestCase
 
     public function testWillRetrieveDependenciesFromContainer(): void
     {
-        $adapters      = $this->createMock(ServiceLocatorInterface::class);
+        $adapters      = $this->createMock(PluginManagerInterface::class);
         $pluginFactory = $this->createMock(StoragePluginFactoryInterface::class);
         $container     = $this->createMock(ContainerInterface::class);
         $container

--- a/test/Service/StorageAdapterFactoryTest.php
+++ b/test/Service/StorageAdapterFactoryTest.php
@@ -14,7 +14,7 @@ use Laminas\Cache\Storage\Adapter\AbstractAdapter;
 use Laminas\Cache\Storage\Plugin\PluginInterface;
 use Laminas\Cache\Storage\PluginAwareInterface;
 use Laminas\Cache\Storage\StorageInterface;
-use Laminas\ServiceManager\ServiceLocatorInterface;
+use Laminas\ServiceManager\PluginManagerInterface;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
@@ -31,7 +31,7 @@ final class StorageAdapterFactoryTest extends TestCase
     /** @var StorageAdapterFactory */
     private $factory;
 
-    /** @var ServiceLocatorInterface&MockObject */
+    /** @var PluginManagerInterface&MockObject */
     private $adapters;
 
     /** @var StoragePluginFactoryInterface&MockObject */
@@ -109,7 +109,7 @@ final class StorageAdapterFactoryTest extends TestCase
     protected function setUp(): void
     {
         parent::setUp();
-        $this->adapters = $this->createMock(ServiceLocatorInterface::class);
+        $this->adapters = $this->createMock(PluginManagerInterface::class);
         $this->plugins  = $this->createMock(StoragePluginFactoryInterface::class);
         $this->factory  = new StorageAdapterFactory($this->adapters, $this->plugins);
     }

--- a/test/Service/StoragePluginFactoryFactoryTest.php
+++ b/test/Service/StoragePluginFactoryFactoryTest.php
@@ -6,7 +6,7 @@ namespace LaminasTest\Cache\Service;
 
 use Laminas\Cache\Service\StoragePluginFactoryFactory;
 use Laminas\Cache\Storage\PluginManager;
-use Laminas\ServiceManager\ServiceLocatorInterface;
+use Laminas\ServiceManager\PluginManagerInterface;
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
 
@@ -23,7 +23,7 @@ final class StoragePluginFactoryFactoryTest extends TestCase
 
     public function testWillRetrieveDependenciesFromContainer(): void
     {
-        $plugins   = $this->createMock(ServiceLocatorInterface::class);
+        $plugins   = $this->createMock(PluginManagerInterface::class);
         $container = $this->createMock(ContainerInterface::class);
         $container
             ->expects(self::once())

--- a/test/Service/StoragePluginFactoryTest.php
+++ b/test/Service/StoragePluginFactoryTest.php
@@ -8,13 +8,13 @@ use Generator;
 use Laminas\Cache\Exception\InvalidArgumentException;
 use Laminas\Cache\Service\StoragePluginFactory;
 use Laminas\Cache\Storage\Plugin\PluginInterface;
-use Laminas\ServiceManager\ServiceLocatorInterface;
+use Laminas\ServiceManager\PluginManagerInterface;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
 final class StoragePluginFactoryTest extends TestCase
 {
-    /** @var ServiceLocatorInterface&MockObject */
+    /** @var PluginManagerInterface&MockObject */
     private $plugins;
 
     /** @var StoragePluginFactory */
@@ -23,7 +23,7 @@ final class StoragePluginFactoryTest extends TestCase
     protected function setUp(): void
     {
         parent::setUp();
-        $this->plugins = $this->createMock(ServiceLocatorInterface::class);
+        $this->plugins = $this->createMock(PluginManagerInterface::class);
         $this->factory = new StoragePluginFactory($this->plugins);
     }
 


### PR DESCRIPTION
<!--
Fill in the relevant information below to help triage your issue.

Pick the target branch based on the following criteria:
  * Documentation improvement: master branch
  * Bugfix: master branch
  * QA improvement (additional tests, CS fixes, etc.) that does not change code
    behavior: master branch
  * New feature, or refactor of existing code: develop branch

You MUST provide a signoff in your commits for us to be able to accept your
patch; you can do this by providing either the --signoff or -s flag when using
"git commit". Please see the project contributing guide and
https://developercertificate.org for details.
-->

|    Q          |   A
|-------------- | ------
| QA            | yes

### Description

<!--
Tell us about why this change is necessary:
- Are you fixing a bug or providing a failing unit test to demonstrate a bug?
  - How do you reproduce it?
  - What did you expect to happen?
  - What actually happened?
  - TARGET THE master BRANCH

- Are you adding documentation?
  - TARGET THE master BRANCH

- Are you providing a QA improvement (additional tests, CS fixes, etc.) that
  does not change behavior?
  - Explain why the changes are necessary
  - TARGET THE master BRANCH

- Are you fixing a BC Break?
  - How do you reproduce it?
  - What was the previous behavior?
  - What is the current behavior?
  - TARGET THE master BRANCH

- Are you adding something the library currently does not support?
  - Why should it be added?
  - What will it enable?
  - How will the code be used?
  - TARGET THE develop BRANCH

- Are you refactoring code?
  - Why do you feel the refactor is necessary?
  - What types of refactoring are you doing?
  - TARGET THE develop BRANCH
-->

With #141, `ServiceLocatorInterface` was used as a dependency to provide mocking capabilities for the `StorageAdapterFactory` and the `StoragePluginFactory`. This was quite rushed to let the tests pass and thus, this PR uses `PluginManagerInterface` as a dependency instead.