### PR TITLE
Update SimpleCacheDecorator.php

### DIFF
--- a/src/Psr/SimpleCache/SimpleCacheDecorator.php
+++ b/src/Psr/SimpleCache/SimpleCacheDecorator.php
@@ -448,7 +448,7 @@ class SimpleCacheDecorator implements SimpleCacheInterface
             $maximumKeyLength = 64;
         }
 
-        // PSR-16 does not allow more then 64 bytes for the key and should not be more than the capabilities of the storage
+        // PSR-16 does not allow more than 64 bytes for the key and should not be more than the capabilities of the storage
         $this->maximumKeyLength = min($maximumKeyLength, 64);
     }
 }

--- a/src/Psr/SimpleCache/SimpleCacheDecorator.php
+++ b/src/Psr/SimpleCache/SimpleCacheDecorator.php
@@ -448,14 +448,7 @@ class SimpleCacheDecorator implements SimpleCacheInterface
             $maximumKeyLength = 64;
         }
 
-        if ($maximumKeyLength < 64) {
-            throw new SimpleCacheInvalidArgumentException(sprintf(
-                'The storage adapter "%s" does not fulfill the minimum requirements for PSR-16:'
-                .' The maximum key length capability must allow at least 64 characters.',
-                get_class($storage)
-            ));
-        }
-
-        $this->maximumKeyLength = $maximumKeyLength;
+        // PSR-16 does not allow more then 64 bytes for the key and should not be more than the capabilities of the storage
+        $this->maximumKeyLength = min($maximumKeyLength, 64);
     }
 }


### PR DESCRIPTION
// PSR-16 does not allow more then 64 bytes for the key and should not be more than the capabilities of the storage

<!--
Fill in the relevant information below to help triage your issue.

Pick the target branch based on the following criteria:
  * Documentation improvement: master branch
  * Bugfix: master branch
  * QA improvement (additional tests, CS fixes, etc.) that does not change code
    behavior: master branch
  * New feature, or refactor of existing code: develop branch

You MUST provide a signoff in your commits for us to be able to accept your
patch; you can do this by providing either the --signoff or -s flag when using
"git commit". Please see the project contributing guide and
https://developercertificate.org for details.
-->

|    Q          |   A
|-------------- | ------ 
| Bugfix        | yes  

### Description

Fixes an issue with SimpleCacheDecorator (PSR-16) that was forcing all storages to have the capability to have a key for at least 64 bytes, but the PSR-16 specifications indicate that a maximum of 64 bytes should be allowed. Having a property that stores the `maximumKeyLength` based on the storage capability and used to validated each key, would mean that smaller keys should be allowed if their length do not exceed the capability of the storage or the specs.

This also fixes PHP warning generated by the pattern used in `preg_match` to validate the length of each key.
