### PR TITLE
Cache key length-validation results in PCRE compilation error

### DIFF
--- a/src/Psr/SimpleCache/SimpleCacheDecorator.php
+++ b/src/Psr/SimpleCache/SimpleCacheDecorator.php
@@ -30,6 +30,12 @@ class SimpleCacheDecorator implements SimpleCacheInterface
     const INVALID_KEY_CHARS = ':@{}()/\\';
 
     /**
+     * PCRE runs into a compilation error if the quantifier exceeds this limit
+     * @internal
+     */
+    public const PCRE_MAXIMUM_QUANTIFIER_LENGTH = 65535;
+
+    /**
      * @var bool
      */
     private $providesPerItemTtl = true;
@@ -456,6 +462,6 @@ class SimpleCacheDecorator implements SimpleCacheInterface
             ));
         }
 
-        $this->maximumKeyLength = $maximumKeyLength;
+        $this->maximumKeyLength = min($maximumKeyLength, self::PCRE_MAXIMUM_QUANTIFIER_LENGTH - 1);
     }
 }

--- a/test/Psr/SimpleCache/SimpleCacheDecoratorTest.php
+++ b/test/Psr/SimpleCache/SimpleCacheDecoratorTest.php
@@ -20,6 +20,7 @@ use Prophecy\Prophecy\ObjectProphecy;
 use Psr\SimpleCache\CacheInterface as SimpleCacheInterface;
 use ReflectionProperty;
 use stdClass;
+use function str_repeat;
 
 /**
  * Test the PSR-16 decorator.
@@ -866,5 +867,29 @@ class SimpleCacheDecoratorTest extends TestCase
         $this->expectExceptionMessage('does not fulfill the minimum requirements for PSR-16');
 
         new SimpleCacheDecorator($storage);
+    }
+
+    public function testWillUsePcreMaximumQuantifierLengthIfAdapterAllowsMoreThanThat(): void
+    {
+        $storage = $this->createMock(StorageInterface::class);
+        $capabilities = $this->getMockCapabilities(
+            null,
+            true,
+            60,
+            SimpleCacheDecorator::PCRE_MAXIMUM_QUANTIFIER_LENGTH
+        );
+
+        $storage
+            ->method('getCapabilities')
+            ->willReturn($capabilities->reveal());
+
+        $decorator = new SimpleCacheDecorator($storage);
+        $key = str_repeat('a', SimpleCacheDecorator::PCRE_MAXIMUM_QUANTIFIER_LENGTH);
+        $this->expectException(SimpleCacheInvalidArgumentException::class);
+        $this->expectExceptionMessage(sprintf(
+            'key is too long. Must be no more than %d characters',
+            SimpleCacheDecorator::PCRE_MAXIMUM_QUANTIFIER_LENGTH - 1
+        ));
+        $decorator->has($key);
     }
 }

--- a/test/Psr/SimpleCache/SimpleCacheDecoratorTest.php
+++ b/test/Psr/SimpleCache/SimpleCacheDecoratorTest.php
@@ -19,7 +19,7 @@ use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ObjectProphecy;
 use Psr\SimpleCache\CacheInterface as SimpleCacheInterface;
 use ReflectionProperty;
-use stdClass;
+use function preg_match;
 use function str_repeat;
 
 /**
@@ -891,5 +891,19 @@ class SimpleCacheDecoratorTest extends TestCase
             SimpleCacheDecorator::PCRE_MAXIMUM_QUANTIFIER_LENGTH - 1
         ));
         $decorator->has($key);
+    }
+
+    public function testPcreMaximumQuantifierLengthWontResultInCompilationError(): void
+    {
+        self::assertEquals(
+            0,
+            preg_match(
+                sprintf(
+                    '/^.{%d,}$/',
+                    SimpleCacheDecorator::PCRE_MAXIMUM_QUANTIFIER_LENGTH
+                ),
+                ''
+            )
+        );
     }
 }


### PR DESCRIPTION
<!--
Fill in the relevant information below to help triage your issue.

Pick the target branch based on the following criteria:
  * Documentation improvement: master branch
  * Bugfix: master branch
  * QA improvement (additional tests, CS fixes, etc.) that does not change code
    behavior: master branch
  * New feature, or refactor of existing code: develop branch

You MUST provide a signoff in your commits for us to be able to accept your
patch; you can do this by providing either the --signoff or -s flag when using
"git commit". Please see the project contributing guide and
https://developercertificate.org for details.
-->

|    Q          |   A
|-------------- | ------
| Bugfix        | yes
| BC Break      | kinda

### Description

<!--
Tell us about why this change is necessary:
- Are you fixing a bug or providing a failing unit test to demonstrate a bug?
  - How do you reproduce it?
  - What did you expect to happen?
  - What actually happened?
  - TARGET THE master BRANCH

- Are you adding documentation?
  - TARGET THE master BRANCH

- Are you providing a QA improvement (additional tests, CS fixes, etc.) that
  does not change behavior?
  - Explain why the changes are necessary
  - TARGET THE master BRANCH

- Are you fixing a BC Break?
  - How do you reproduce it?
  - What was the previous behavior?
  - What is the current behavior?
  - TARGET THE master BRANCH

- Are you adding something the library currently does not support?
  - Why should it be added?
  - What will it enable?
  - How will the code be used?
  - TARGET THE develop BRANCH

- Are you refactoring code?
  - Why do you feel the refactor is necessary?
  - What types of refactoring are you doing?
  - TARGET THE develop BRANCH
-->

With [2.12.0](https://github.com/laminas/laminas-cache/releases/tag/2.12.0), we introduced a better key length handling for the `PSR-16` decorator. It initially only supported 64 characters which was the minimum which `PSR-16` requires to be supported by implementing cache backends.
The redis adapter can take keys up to 512 MB and thus, this was changed in that adapter.

When allowing key length `>65534`, PCRE2 will end up in a compilation error. To avoid this, we are decreasing the maximum supported key length for PSR-16 caches to `65534`. Technically, this would be a BC break but given the fact, that cache adapters which state to support longer keys would lead to errors while validating the cache keys, we should be fine.