### PR TITLE
Provide interface factory for `StorageAdapterFactoryInterface`

### DIFF
--- a/src/ConfigProvider.php
+++ b/src/ConfigProvider.php
@@ -6,6 +6,8 @@ use Laminas\Cache\Command\DeprecatedStorageFactoryConfigurationCheckCommand;
 use Laminas\Cache\Command\DeprecatedStorageFactoryConfigurationCheckCommandFactory;
 use Laminas\Cache\Service\StorageAdapterFactory;
 use Laminas\Cache\Service\StorageAdapterFactoryFactory;
+use Laminas\Cache\Service\StorageAdapterFactoryInterface;
+use Laminas\Cache\Service\StoragePluginFactory;
 use Laminas\Cache\Service\StoragePluginFactoryFactory;
 use Laminas\Cache\Service\StoragePluginFactoryInterface;
 use Symfony\Component\Console\Command\Command;
@@ -39,10 +41,12 @@ class ConfigProvider
                 Service\StorageCacheAbstractServiceFactory::class,
             ],
             'factories'          => [
-                Storage\AdapterPluginManager::class  => Service\StorageAdapterPluginManagerFactory::class,
-                Storage\PluginManager::class         => Service\StoragePluginManagerFactory::class,
-                StoragePluginFactoryInterface::class => StoragePluginFactoryFactory::class,
-                StorageAdapterFactory::class         => StorageAdapterFactoryFactory::class,
+                Storage\AdapterPluginManager::class   => Service\StorageAdapterPluginManagerFactory::class,
+                Storage\PluginManager::class          => Service\StoragePluginManagerFactory::class,
+                StoragePluginFactory::class           => StoragePluginFactoryFactory::class,
+                StoragePluginFactoryInterface::class  => StoragePluginFactoryFactory::class,
+                StorageAdapterFactory::class          => StorageAdapterFactoryFactory::class,
+                StorageAdapterFactoryInterface::class => StorageAdapterFactoryFactory::class,
             ],
         ];
 


### PR DESCRIPTION
<!--
Fill in the relevant information below to help triage your issue.

Pick the target branch based on the following criteria:
  * Documentation improvement: master branch
  * Bugfix: master branch
  * QA improvement (additional tests, CS fixes, etc.) that does not change code
    behavior: master branch
  * New feature, or refactor of existing code: develop branch

You MUST provide a signoff in your commits for us to be able to accept your
patch; you can do this by providing either the --signoff or -s flag when using
"git commit". Please see the project contributing guide and
https://developercertificate.org for details.
-->

|    Q          |   A
|-------------- | ------
| New Feature   | yes

### Description

<!--
Tell us about why this change is necessary:
- Are you fixing a bug or providing a failing unit test to demonstrate a bug?
  - How do you reproduce it?
  - What did you expect to happen?
  - What actually happened?
  - TARGET THE master BRANCH

- Are you adding documentation?
  - TARGET THE master BRANCH

- Are you providing a QA improvement (additional tests, CS fixes, etc.) that
  does not change behavior?
  - Explain why the changes are necessary
  - TARGET THE master BRANCH

- Are you fixing a BC Break?
  - How do you reproduce it?
  - What was the previous behavior?
  - What is the current behavior?
  - TARGET THE master BRANCH

- Are you adding something the library currently does not support?
  - Why should it be added?
  - What will it enable?
  - How will the code be used?
  - TARGET THE develop BRANCH

- Are you refactoring code?
  - Why do you feel the refactor is necessary?
  - What types of refactoring are you doing?
  - TARGET THE develop BRANCH
-->

In v2.12.0, there were aliases from the interfaces to the specific services. With the merge-up, this was removed and thus is re-implemented here in a different way.
Due to some delegation issues, e.g., aliases should not be used for services.

This also adds dedicated factories for the service `StoragePluginFactory` to be in sync with the `StorageAdapterFactoryInterface`.