### PR TITLE
Regression: `SimpleCacheDecorator` methods consuming iterable arguments called with non-iterable arguments throw `TypeError`

### DIFF
--- a/.laminas-ci.json
+++ b/.laminas-ci.json
@@ -4,5 +4,9 @@
     },
     "extensions": [
         "apcu"
+    ],
+    "ini": [
+        "apcu.enabled=1",
+        "apcu.enable_cli=1"
     ]
 }

--- a/.laminas-ci.json
+++ b/.laminas-ci.json
@@ -6,7 +6,7 @@
         "apcu"
     ],
     "ini": [
-        "apcu.enabled=1",
-        "apcu.enable_cli=1"
+        "apc.enabled=1",
+        "apc.enable_cli=1"
     ]
 }

--- a/composer.json
+++ b/composer.json
@@ -42,6 +42,7 @@
         "laminas/laminas-cache-storage-adapter-blackhole": "2.0.x-dev",
         "laminas/laminas-cache-storage-adapter-filesystem": "2.0.x-dev",
         "laminas/laminas-cache-storage-adapter-memory": "2.0.x-dev",
+        "laminas/laminas-cache-storage-adapter-test": "2.0.x-dev",
         "laminas/laminas-cli": "^1.0",
         "laminas/laminas-coding-standard": "~2.2.0",
         "laminas/laminas-config-aggregator": "^1.5",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "edf647c91c6b8f72b4b4686ed05739c5",
+    "content-hash": "cab85862cd4674222b526633f5fd5654",
     "packages": [
         {
             "name": "container-interop/container-interop",
@@ -881,6 +881,131 @@
             "time": "2021-02-10T13:53:07+00:00"
         },
         {
+            "name": "cache/integration-tests",
+            "version": "0.17.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-cache/integration-tests.git",
+                "reference": "eda2e6b8bc5abcd623c8047e2345cda38dd6479e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-cache/integration-tests/zipball/eda2e6b8bc5abcd623c8047e2345cda38dd6479e",
+                "reference": "eda2e6b8bc5abcd623c8047e2345cda38dd6479e",
+                "shasum": ""
+            },
+            "require": {
+                "cache/tag-interop": "^1.0",
+                "php": ">=5.5.9",
+                "psr/cache": "~1.0"
+            },
+            "conflict": {
+                "phpunit/phpunit": "<4.8.35|<5.4.3,>=5.0"
+            },
+            "require-dev": {
+                "cache/cache": "^1.0",
+                "illuminate/cache": "^5.4|^5.5|^5.6",
+                "mockery/mockery": "^1.0",
+                "symfony/cache": "^3.4.31|^4.3.4|^5.0",
+                "symfony/phpunit-bridge": "^5.1",
+                "tedivm/stash": "^0.14"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Cache\\IntegrationTests\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Aaron Scherer",
+                    "email": "aequasi@gmail.com",
+                    "homepage": "https://github.com/aequasi"
+                },
+                {
+                    "name": "Tobias Nyholm",
+                    "email": "tobias.nyholm@gmail.com",
+                    "homepage": "https://github.com/nyholm"
+                }
+            ],
+            "description": "Integration tests for PSR-6 and PSR-16 cache implementations",
+            "homepage": "https://github.com/php-cache/integration-tests",
+            "keywords": [
+                "cache",
+                "psr16",
+                "psr6",
+                "test"
+            ],
+            "support": {
+                "issues": "https://github.com/php-cache/integration-tests/issues",
+                "source": "https://github.com/php-cache/integration-tests/tree/0.17.0"
+            },
+            "time": "2020-11-03T12:52:23+00:00"
+        },
+        {
+            "name": "cache/tag-interop",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-cache/tag-interop.git",
+                "reference": "909a5df87e698f1665724a9e84851c11c45fbfb9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-cache/tag-interop/zipball/909a5df87e698f1665724a9e84851c11c45fbfb9",
+                "reference": "909a5df87e698f1665724a9e84851c11c45fbfb9",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.5 || ^7.0 || ^8.0",
+                "psr/cache": "^1.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.1-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Cache\\TagInterop\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Tobias Nyholm",
+                    "email": "tobias.nyholm@gmail.com",
+                    "homepage": "https://github.com/nyholm"
+                },
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com",
+                    "homepage": "https://github.com/nicolas-grekas"
+                }
+            ],
+            "description": "Framework interoperable interfaces for tags",
+            "homepage": "https://www.php-cache.com/en/latest/",
+            "keywords": [
+                "cache",
+                "psr",
+                "psr6",
+                "tag"
+            ],
+            "support": {
+                "issues": "https://github.com/php-cache/tag-interop/issues",
+                "source": "https://github.com/php-cache/tag-interop/tree/1.0.1"
+            },
+            "time": "2020-12-04T14:11:04+00:00"
+        },
+        {
             "name": "composer/package-versions-deprecated",
             "version": "1.11.99.4",
             "source": {
@@ -1729,6 +1854,67 @@
                 }
             ],
             "time": "2021-09-14T22:19:43+00:00"
+        },
+        {
+            "name": "laminas/laminas-cache-storage-adapter-test",
+            "version": "2.0.x-dev",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laminas/laminas-cache-storage-adapter-test.git",
+                "reference": "12f4c2f4a5d1fb5f963a30ab0be76f2ea76f89b5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laminas/laminas-cache-storage-adapter-test/zipball/12f4c2f4a5d1fb5f963a30ab0be76f2ea76f89b5",
+                "reference": "12f4c2f4a5d1fb5f963a30ab0be76f2ea76f89b5",
+                "shasum": ""
+            },
+            "require": {
+                "cache/integration-tests": "^0.17",
+                "container-interop/container-interop": "^1.2",
+                "laminas/laminas-cache": "^3.0",
+                "php": "^7.3 || ~8.0.0 || ~8.1.0",
+                "phpunit/phpunit": "^9.5.9"
+            },
+            "require-dev": {
+                "laminas/laminas-cache-storage-adapter-memory": "^1.1",
+                "laminas/laminas-coding-standard": "~2.3.0",
+                "psalm/plugin-phpunit": "^0.16.1",
+                "vimeo/psalm": "^4.7"
+            },
+            "default-branch": true,
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "LaminasTest\\Cache\\Storage\\Adapter\\": "src/"
+                },
+                "files": [
+                    "autoload/phpunit-backward-compatibility.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "Laminas cache storage adapter shared test dependency",
+            "keywords": [
+                "cache",
+                "laminas",
+                "test"
+            ],
+            "support": {
+                "forum": "https://discourse.laminas.dev/",
+                "issues": "https://github.com/laminas/laminas-cache-storage-adapter-test/issues",
+                "rss": "https://github.com/laminas/laminas-cache-storage-adapter-test/releases.atom",
+                "source": "https://github.com/laminas/laminas-cache-storage-adapter-test"
+            },
+            "funding": [
+                {
+                    "url": "https://funding.communitybridge.org/projects/laminas-project",
+                    "type": "community_bridge"
+                }
+            ],
+            "time": "2021-09-14T23:07:54+00:00"
         },
         {
             "name": "laminas/laminas-cli",
@@ -6208,7 +6394,8 @@
         "laminas/laminas-cache-storage-adapter-apcu": 20,
         "laminas/laminas-cache-storage-adapter-blackhole": 20,
         "laminas/laminas-cache-storage-adapter-filesystem": 20,
-        "laminas/laminas-cache-storage-adapter-memory": 20
+        "laminas/laminas-cache-storage-adapter-memory": 20,
+        "laminas/laminas-cache-storage-adapter-test": 20
     },
     "prefer-stable": false,
     "prefer-lowest": false,

--- a/src/Psr/SimpleCache/SimpleCacheDecorator.php
+++ b/src/Psr/SimpleCache/SimpleCacheDecorator.php
@@ -13,10 +13,12 @@ use Laminas\Cache\Storage\FlushableInterface;
 use Laminas\Cache\Storage\StorageInterface;
 use Psr\SimpleCache\CacheInterface as SimpleCacheInterface;
 use Throwable;
+use Traversable;
 
 use function array_keys;
 use function get_class;
 use function gettype;
+use function is_array;
 use function is_int;
 use function is_object;
 use function is_string;
@@ -180,6 +182,16 @@ class SimpleCacheDecorator implements SimpleCacheInterface
      */
     public function getMultiple($keys, $default = null)
     {
+        /**
+         * @psalm-suppress DocblockTypeContradiction Since we do not have native type-hints, we should verify iterable.
+         */
+        if (! is_array($keys) && ! $keys instanceof Traversable) {
+            throw new SimpleCacheInvalidArgumentException(sprintf(
+                'Invalid value provided to %s; must be iterable',
+                __METHOD__
+            ));
+        }
+
         $keys = $this->convertIterableKeysToList($keys);
 
         try {
@@ -203,6 +215,16 @@ class SimpleCacheDecorator implements SimpleCacheInterface
      */
     public function setMultiple($values, $ttl = null)
     {
+        /**
+         * @psalm-suppress DocblockTypeContradiction Since we do not have native type-hints, we should verify iterable.
+         */
+        if (! is_array($values) && ! $values instanceof Traversable) {
+            throw new SimpleCacheInvalidArgumentException(sprintf(
+                'Invalid value provided to %s; must be iterable',
+                __METHOD__
+            ));
+        }
+
         $values = $this->convertIterableToKeyValueMap($values);
         $keys   = array_keys($values);
         $ttl    = $this->convertTtlToInteger($ttl);
@@ -252,6 +274,16 @@ class SimpleCacheDecorator implements SimpleCacheInterface
      */
     public function deleteMultiple($keys)
     {
+        /**
+         * @psalm-suppress DocblockTypeContradiction Since we do not have native type-hints, we should verify iterable.
+         */
+        if (! is_array($keys) && ! $keys instanceof Traversable) {
+            throw new SimpleCacheInvalidArgumentException(sprintf(
+                'Invalid value provided to %s; must be iterable',
+                __METHOD__
+            ));
+        }
+
         $keys = $this->convertIterableKeysToList($keys);
         if (empty($keys)) {
             return true;

--- a/test/Psr/CacheItemPool/CacheItemPoolIntegrationTest.php
+++ b/test/Psr/CacheItemPool/CacheItemPoolIntegrationTest.php
@@ -13,7 +13,7 @@ final class CacheItemPoolIntegrationTest extends AbstractCacheItemPoolIntegratio
 {
     protected function createStorage(): StorageInterface
     {
-        $storage = new Apcu();
+        $storage    = new Apcu();
         $serializer = new Serializer();
         $storage->addPlugin($serializer);
 

--- a/test/Psr/CacheItemPool/CacheItemPoolIntegrationTest.php
+++ b/test/Psr/CacheItemPool/CacheItemPoolIntegrationTest.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LaminasTest\Cache\Psr\CacheItemPool;
+
+use Laminas\Cache\Storage\Adapter\Apcu;
+use Laminas\Cache\Storage\Plugin\Serializer;
+use Laminas\Cache\Storage\StorageInterface;
+use LaminasTest\Cache\Storage\Adapter\AbstractCacheItemPoolIntegrationTest;
+
+final class CacheItemPoolIntegrationTest extends AbstractCacheItemPoolIntegrationTest
+{
+    protected function createStorage(): StorageInterface
+    {
+        $storage = new Apcu();
+        $serializer = new Serializer();
+        $storage->addPlugin($serializer);
+
+        return $storage;
+    }
+}

--- a/test/Psr/SimpleCache/SimpleCacheIntegrationTest.php
+++ b/test/Psr/SimpleCache/SimpleCacheIntegrationTest.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LaminasTest\Cache\Psr\SimpleCache;
+
+use Laminas\Cache\Storage\Adapter\Apcu;
+use Laminas\Cache\Storage\Plugin\Serializer;
+use Laminas\Cache\Storage\StorageInterface;
+use LaminasTest\Cache\Storage\Adapter\AbstractSimpleCacheIntegrationTest;
+
+final class SimpleCacheIntegrationTest extends AbstractSimpleCacheIntegrationTest
+{
+    protected function createStorage(): StorageInterface
+    {
+        $storage = new Apcu();
+        $serializer = new Serializer();
+        $storage->addPlugin($serializer);
+
+        return $storage;
+    }
+}

--- a/test/Psr/SimpleCache/SimpleCacheIntegrationTest.php
+++ b/test/Psr/SimpleCache/SimpleCacheIntegrationTest.php
@@ -13,7 +13,7 @@ final class SimpleCacheIntegrationTest extends AbstractSimpleCacheIntegrationTes
 {
     protected function createStorage(): StorageInterface
     {
-        $storage = new Apcu();
+        $storage    = new Apcu();
         $serializer = new Serializer();
         $storage->addPlugin($serializer);
 


### PR DESCRIPTION
<!--
Fill in the relevant information below to help triage your issue.

Pick the target branch based on the following criteria:
  * Documentation improvement: master branch
  * Bugfix: master branch
  * QA improvement (additional tests, CS fixes, etc.) that does not change code
    behavior: master branch
  * New feature, or refactor of existing code: develop branch

You MUST provide a signoff in your commits for us to be able to accept your
patch; you can do this by providing either the --signoff or -s flag when using
"git commit". Please see the project contributing guide and
https://developercertificate.org for details.
-->

|    Q          |   A
|-------------- | ------
| Bugfix        | yes

### Description

<!--
Tell us about why this change is necessary:
- Are you fixing a bug or providing a failing unit test to demonstrate a bug?
  - How do you reproduce it?
  - What did you expect to happen?
  - What actually happened?
  - TARGET THE master BRANCH

- Are you adding documentation?
  - TARGET THE master BRANCH

- Are you providing a QA improvement (additional tests, CS fixes, etc.) that
  does not change behavior?
  - Explain why the changes are necessary
  - TARGET THE master BRANCH

- Are you fixing a BC Break?
  - How do you reproduce it?
  - What was the previous behavior?
  - What is the current behavior?
  - TARGET THE master BRANCH

- Are you adding something the library currently does not support?
  - Why should it be added?
  - What will it enable?
  - How will the code be used?
  - TARGET THE develop BRANCH

- Are you refactoring code?
  - Why do you feel the refactor is necessary?
  - What types of refactoring are you doing?
  - TARGET THE develop BRANCH
-->

Fix regression introduced in https://github.com/laminas/laminas-cache/pull/165. Even tho, PSR-16 states to only allow `iterable` we should handle type errors until that interface introduces native type-hints.
