### PR TITLE
Allow installation on PHP 8.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         }
     },
     "require": {
-        "php": "^7.3 || ~8.0.0",
+        "php": "^7.3 || ~8.0.0 || ~8.1.0",
         "laminas/laminas-cache-storage-adapter-apc": "^1.0",
         "laminas/laminas-cache-storage-adapter-apcu": "^1.0",
         "laminas/laminas-cache-storage-adapter-blackhole": "^1.0",


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description

Allow installation on PHP 8.1 for 2.13.x version.