### PR TITLE
PSR-6 maximum cache key length validation

### DIFF
--- a/docs/book/v3/reference/migration.md
+++ b/docs/book/v3/reference/migration.md
@@ -16,11 +16,13 @@ In the past, most of the adapters Laminas does officially support were not prope
 4. Cache adapters which are used within the project needs to be required in at least `^2.0`; in case you don't know which adapters are in use, either check your project configuration or search for the `Laminas\Cache\Storage\Adapter` namespace in your projects source code. Every adapter has to be listed in either your `module.config.php` (laminas-mvc) or `config.php` (mezzio) configuration. 
 5. Project does not use any of the [removed classes and traits](#removed-classes-and-traits)
 6. Storage adapters are not extended in any way as [all adapters are `final`](#breaking-changes) starting with v2.0 of the individual adapter component
+7. PSR-6 `CacheItemPoolDecorator` does now validate the maximum key length the same way as PSR-6 `SimpleCacheDecorator` and therefore fulfills the requirements by the underlying PSR.
 
 ## New Features
 
 - Each cache adapter has its [own package](#satellite-packages).
 - Support for PHP 8.1
+- PSR-6 `CacheItemPoolDecorator` validates the maximum key length.
 
 ## Removed Classes and Traits
 
@@ -39,6 +41,9 @@ With `laminas-cache` v3, some classes/traits were removed as well:
 **Please note that it is not possible to inject the pattern configuration as an array anymore**
 - Storage configurations must be in a specific shape. For more details, head to the release notes of [2.12.0](https://github.com/laminas/laminas-cache/releases/tag/2.12.0)
 - All cache adapters are now marked as `final` and are not extensible anymore. In case that you are extending one of the cache adapters, please switch change your code as `composition` should be preferred over inheritance. For an example, please check out the [composition over inheritance](#composition-over-inheritance) section.
+- Due to the enhancement of `CacheItemPoolDecorator`, the maximum key length for the underlying cache adapter is validated before it is passed to the adapter.
+- The `SerializationTrait` which was meant to be used by both `PSR-6` and `PSR-16` decorators is now marked as `internal`.
+- The `PCRE_MAXIMUM_QUANTIFIER_LENGTH` constant of the `SimpleCacheDecorator` (which was marked as `internal`) has now been moved to the new (also `internal`) `MaximumKeyLengthTrait` and thus had to become a public static property (as traits do not support constants).
 
 ## Satellite Packages
 

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -214,12 +214,6 @@
       <code>is_object($ttl)</code>
       <code>null === $ttl</code>
     </DocblockTypeContradiction>
-    <InvalidReturnStatement occurrences="1">
-      <code>new $exceptionClass($throwable-&gt;getMessage(), $throwable-&gt;getCode(), $throwable)</code>
-    </InvalidReturnStatement>
-    <InvalidReturnType occurrences="1">
-      <code>SimpleCacheException</code>
-    </InvalidReturnType>
     <MixedArgument occurrences="3">
       <code>$key</code>
       <code>$key</code>
@@ -849,9 +843,6 @@
       <code>$key</code>
       <code>$key</code>
     </MixedArgument>
-    <MixedArgumentTypeCoercion occurrences="1">
-      <code>$capabilities ?? $this-&gt;defaultCapabilities</code>
-    </MixedArgumentTypeCoercion>
     <MixedAssignment occurrences="3">
       <code>$item</code>
       <code>$item</code>

--- a/src/Psr/CacheItemPool/InvalidArgumentException.php
+++ b/src/Psr/CacheItemPool/InvalidArgumentException.php
@@ -4,6 +4,16 @@ namespace Laminas\Cache\Psr\CacheItemPool;
 
 use Psr\Cache\InvalidArgumentException as InvalidArgumentExceptionInterface;
 
+use function sprintf;
+
 class InvalidArgumentException extends \InvalidArgumentException implements InvalidArgumentExceptionInterface
 {
+    public static function maximumKeyLengthExceeded(string $key, int $maximumKeyLength): self
+    {
+        return new self(sprintf(
+            'Invalid key "%s" provided; key is too long. Must be no more than %d characters',
+            $key,
+            $maximumKeyLength
+        ));
+    }
 }

--- a/src/Psr/MaximumKeyLengthTrait.php
+++ b/src/Psr/MaximumKeyLengthTrait.php
@@ -26,6 +26,7 @@ trait MaximumKeyLengthTrait
      * @internal
      *
      * @readonly
+     * @var positive-int
      */
     public static $PCRE_MAXIMUM_QUANTIFIER_LENGTH = 65535;
 

--- a/src/Psr/MaximumKeyLengthTrait.php
+++ b/src/Psr/MaximumKeyLengthTrait.php
@@ -52,7 +52,7 @@ trait MaximumKeyLengthTrait
 
         if ($maximumKeyLength < 64) {
             throw new SimpleCacheInvalidArgumentException(sprintf(
-                'The storage adapter "%s" does not fulfill the minimum requirements for PSR-16:'
+                'The storage adapter "%s" does not fulfill the minimum requirements for PSR-6/PSR-16:'
                 . ' The maximum key length capability must allow at least 64 characters.',
                 get_class($storage)
             ));

--- a/src/Psr/MaximumKeyLengthTrait.php
+++ b/src/Psr/MaximumKeyLengthTrait.php
@@ -28,7 +28,7 @@ trait MaximumKeyLengthTrait
      * @readonly
      * @var positive-int
      */
-    public static $PCRE_MAXIMUM_QUANTIFIER_LENGTH = 65535;
+    public static $pcreMaximumQuantifierLength = 65535;
 
     /**
      * @var int
@@ -59,7 +59,7 @@ trait MaximumKeyLengthTrait
         }
 
         /** @psalm-suppress PropertyTypeCoercion The result of this will always be > 0 */
-        $this->maximumKeyLength = min($maximumKeyLength, self::$PCRE_MAXIMUM_QUANTIFIER_LENGTH - 1);
+        $this->maximumKeyLength = min($maximumKeyLength, self::$pcreMaximumQuantifierLength - 1);
     }
 
     private function exceedsMaximumKeyLength(string $key): bool

--- a/src/Psr/MaximumKeyLengthTrait.php
+++ b/src/Psr/MaximumKeyLengthTrait.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laminas\Cache\Psr;
+
+use Laminas\Cache\Psr\SimpleCache\SimpleCacheInvalidArgumentException;
+use Laminas\Cache\Storage\Capabilities;
+use Laminas\Cache\Storage\StorageInterface;
+
+use function get_class;
+use function min;
+use function preg_match;
+use function sprintf;
+
+/**
+ * Provides memoizing of maximum key length for a storage adapter.
+ *
+ * @internal
+ */
+trait MaximumKeyLengthTrait
+{
+    /**
+     * PCRE runs into a compilation error if the quantifier exceeds this limit
+     *
+     * @internal
+     *
+     * @readonly
+     */
+    public static $PCRE_MAXIMUM_QUANTIFIER_LENGTH = 65535;
+
+    /**
+     * @var int
+     * @psalm-var 0|positive-int
+     */
+    private $maximumKeyLength;
+
+    private function memoizeMaximumKeyLengthCapability(StorageInterface $storage, Capabilities $capabilities): void
+    {
+        $maximumKeyLength = $capabilities->getMaxKeyLength();
+
+        if ($maximumKeyLength === Capabilities::UNLIMITED_KEY_LENGTH) {
+            $this->maximumKeyLength = Capabilities::UNLIMITED_KEY_LENGTH;
+            return;
+        }
+
+        if ($maximumKeyLength === Capabilities::UNKNOWN_KEY_LENGTH) {
+            // For backward compatibility, assume adapters which do not provide a maximum key length do support 64 chars
+            $maximumKeyLength = 64;
+        }
+
+        if ($maximumKeyLength < 64) {
+            throw new SimpleCacheInvalidArgumentException(sprintf(
+                'The storage adapter "%s" does not fulfill the minimum requirements for PSR-16:'
+                . ' The maximum key length capability must allow at least 64 characters.',
+                get_class($storage)
+            ));
+        }
+
+        /** @psalm-suppress PropertyTypeCoercion The result of this will always be > 0 */
+        $this->maximumKeyLength = min($maximumKeyLength, self::$PCRE_MAXIMUM_QUANTIFIER_LENGTH - 1);
+    }
+
+    private function exceedsMaximumKeyLength(string $key): bool
+    {
+        return $this->maximumKeyLength !== Capabilities::UNLIMITED_KEY_LENGTH
+            && preg_match('/^.{' . ($this->maximumKeyLength + 1) . ',}/u', $key);
+    }
+}

--- a/src/Psr/SerializationTrait.php
+++ b/src/Psr/SerializationTrait.php
@@ -9,6 +9,8 @@ use function in_array;
 /**
  * Provides common functionality surrounding value de/serialization as required
  * by both PSR-6 and PSR-16
+ *
+ * @internal
  */
 trait SerializationTrait
 {

--- a/src/Psr/SimpleCache/SimpleCacheInvalidArgumentException.php
+++ b/src/Psr/SimpleCache/SimpleCacheInvalidArgumentException.php
@@ -5,6 +5,16 @@ namespace Laminas\Cache\Psr\SimpleCache;
 use InvalidArgumentException;
 use Psr\SimpleCache\InvalidArgumentException as PsrInvalidArgumentException;
 
+use function sprintf;
+
 class SimpleCacheInvalidArgumentException extends InvalidArgumentException implements PsrInvalidArgumentException
 {
+    public static function maximumKeyLengthExceeded(string $key, int $maximumKeyLength): self
+    {
+        return new self(sprintf(
+            'Invalid key "%s" provided; key is too long. Must be no more than %d characters',
+            $key,
+            $maximumKeyLength
+        ));
+    }
 }

--- a/test/Psr/CacheItemPool/CacheItemPoolDecoratorTest.php
+++ b/test/Psr/CacheItemPool/CacheItemPoolDecoratorTest.php
@@ -884,11 +884,6 @@ final class CacheItemPoolDecoratorTest extends TestCase
         return new CacheItemPoolDecorator($storage);
     }
 
-    private function createAdapterOptions(?array $options = null): AdapterOptions
-    {
-        return new AdapterOptions($options);
-    }
-
     protected function tearDown(): void
     {
         try {

--- a/test/Psr/CacheItemPool/CacheItemPoolDecoratorTest.php
+++ b/test/Psr/CacheItemPool/CacheItemPoolDecoratorTest.php
@@ -984,7 +984,7 @@ final class CacheItemPoolDecoratorTest extends TestCase
             null,
             true,
             60,
-            SimpleCacheDecorator::$PCRE_MAXIMUM_QUANTIFIER_LENGTH
+            SimpleCacheDecorator::$pcreMaximumQuantifierLength
         );
 
         $storage
@@ -992,11 +992,11 @@ final class CacheItemPoolDecoratorTest extends TestCase
             ->willReturn($capabilities);
 
         $decorator = new CacheItemPoolDecorator($storage);
-        $key       = str_repeat('a', CacheItemPoolDecorator::$PCRE_MAXIMUM_QUANTIFIER_LENGTH);
+        $key       = str_repeat('a', CacheItemPoolDecorator::$pcreMaximumQuantifierLength);
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage(sprintf(
             'key is too long. Must be no more than %d characters',
-            CacheItemPoolDecorator::$PCRE_MAXIMUM_QUANTIFIER_LENGTH - 1
+            CacheItemPoolDecorator::$pcreMaximumQuantifierLength - 1
         ));
         $decorator->getItem($key);
     }
@@ -1008,7 +1008,7 @@ final class CacheItemPoolDecoratorTest extends TestCase
             preg_match(
                 sprintf(
                     '/^.{%d,}$/',
-                    CacheItemPoolDecorator::$PCRE_MAXIMUM_QUANTIFIER_LENGTH
+                    CacheItemPoolDecorator::$pcreMaximumQuantifierLength
                 ),
                 ''
             )

--- a/test/Psr/CacheItemPool/CacheItemPoolDecoratorTest.php
+++ b/test/Psr/CacheItemPool/CacheItemPoolDecoratorTest.php
@@ -8,6 +8,7 @@ use Laminas\Cache\Psr\CacheItemPool\CacheException;
 use Laminas\Cache\Psr\CacheItemPool\CacheItem;
 use Laminas\Cache\Psr\CacheItemPool\CacheItemPoolDecorator;
 use Laminas\Cache\Psr\CacheItemPool\InvalidArgumentException;
+use Laminas\Cache\Psr\SimpleCache\SimpleCacheDecorator;
 use Laminas\Cache\Storage\Adapter\AdapterOptions;
 use Laminas\Cache\Storage\Capabilities;
 use Laminas\Cache\Storage\ClearByNamespaceInterface;
@@ -24,49 +25,53 @@ use Throwable;
 
 use function array_keys;
 use function array_map;
-use function assert;
+use function preg_match;
+use function sprintf;
+use function str_repeat;
 use function time;
 
 final class CacheItemPoolDecoratorTest extends TestCase
 {
-    /** @var array<string,mixed> */
-    protected $defaultCapabilities = [
-        'staticTtl'          => true,
-        'minTtl'             => 1,
-        'supportedDatatypes' => [
-            'NULL'     => true,
-            'boolean'  => true,
-            'integer'  => true,
-            'double'   => true,
-            'string'   => true,
-            'array'    => true,
-            'object'   => 'object',
-            'resource' => false,
-        ],
-    ];
-
     /** @var StorageInterface&FlushableInterface&MockObject */
     private $storage;
 
     /** @var CacheItemPoolDecorator */
     private $adapter;
 
+    /** @var array<string,bool|string> */
+    private $requiredTypes = [
+        'NULL'     => true,
+        'boolean'  => true,
+        'integer'  => true,
+        'double'   => true,
+        'string'   => true,
+        'array'    => true,
+        'object'   => 'object',
+        'resource' => false,
+    ];
+
+    /** @var AdapterOptions&MockObject */
+    private $options;
+
     protected function setUp(): void
     {
         parent::setUp();
+        $this->options = $this->createMock(AdapterOptions::class);
         $this->storage = $this->createMockedStorage();
         $this->adapter = $this->getAdapter($this->storage);
     }
-
-    /** @var (AdapterOptions&MockObject)|null */
-    private $optionsMock;
 
     /**
      * @return StorageInterface&FlushableInterface&ClearByNamespaceInterface&MockObject
      */
     private function createMockedStorage(
-        ?array $capabilities = null,
-        ?array $options = null
+        ?AdapterOptions $options = null,
+        ?array $supportedDataTypes = null,
+        bool $staticTtl = true,
+        int $minTtl = 1,
+        int $maxKeyLength = -1,
+        bool $useRequestTime = false,
+        bool $lockOnExpire = false
     ): StorageInterface {
         $storage = $this->createMock(FlushableNamespaceStorageInterface::class);
 
@@ -74,9 +79,14 @@ final class CacheItemPoolDecoratorTest extends TestCase
             ->method('getEventManager')
             ->willReturn(new EventManager());
 
-        $capabilities = $this->createCapabilitiesMock(
+        $capabilities = $this->createCapabilities(
             $storage,
-            $capabilities ?? $this->defaultCapabilities
+            $supportedDataTypes,
+            $staticTtl,
+            $minTtl,
+            $maxKeyLength,
+            $useRequestTime,
+            $lockOnExpire
         );
 
         $storage
@@ -85,7 +95,7 @@ final class CacheItemPoolDecoratorTest extends TestCase
 
         $storage
             ->method('getOptions')
-            ->willReturn($this->createOptionsMock($options));
+            ->willReturn($options ?? $this->options);
 
         return $storage;
     }
@@ -95,7 +105,7 @@ final class CacheItemPoolDecoratorTest extends TestCase
         $this->expectException(CacheException::class);
         $storage = $this->createMock(StorageInterface::class);
 
-        $capabilities = new Capabilities($storage, new stdClass(), $this->defaultCapabilities);
+        $capabilities = $this->createCapabilities($storage);
 
         $storage
             ->expects(self::once())
@@ -110,21 +120,16 @@ final class CacheItemPoolDecoratorTest extends TestCase
         $this->expectException(CacheException::class);
         $storage = $this->createMock(StorageInterface::class);
 
-        $dataTypes    = [
-            'staticTtl'          => true,
-            'minTtl'             => 1,
-            'supportedDatatypes' => [
-                'NULL'     => true,
-                'boolean'  => true,
-                'integer'  => true,
-                'double'   => false,
-                'string'   => true,
-                'array'    => true,
-                'object'   => 'object',
-                'resource' => false,
-            ],
-        ];
-        $capabilities = new Capabilities($storage, new stdClass(), $dataTypes);
+        $capabilities = $this->createCapabilities($storage, [
+            'NULL'     => true,
+            'boolean'  => true,
+            'integer'  => true,
+            'double'   => false,
+            'string'   => true,
+            'array'    => true,
+            'object'   => 'object',
+            'resource' => false,
+        ]);
 
         $storage
             ->expects(self::once())
@@ -137,14 +142,14 @@ final class CacheItemPoolDecoratorTest extends TestCase
     public function testStorageFalseStaticTtlThrowsException(): void
     {
         $this->expectException(CacheException::class);
-        $storage = $this->createMockedStorage(['staticTtl' => false]);
+        $storage = $this->createMockedStorage(null, null, false);
         $this->getAdapter($storage);
     }
 
     public function testStorageZeroMinTtlThrowsException(): void
     {
         $this->expectException(CacheException::class);
-        $storage = $this->createMockedStorage(['staticTtl' => true, 'minTtl' => 0]);
+        $storage = $this->createMockedStorage(null, null, true, 0);
         $this->getAdapter($storage);
     }
 
@@ -342,8 +347,7 @@ final class CacheItemPoolDecoratorTest extends TestCase
             ->with('foo')
             ->willReturn(null);
 
-        assert($this->optionsMock instanceof MockObject);
-        $this->optionsMock
+        $this->options
             ->expects(self::exactly(2))
             ->method('setTtl')
             ->withConsecutive([3600], [0])
@@ -390,8 +394,7 @@ final class CacheItemPoolDecoratorTest extends TestCase
             ->with(['foo' => 'bar'])
             ->willReturn(['foo' => true]);
 
-        assert($this->optionsMock instanceof MockObject);
-        $this->optionsMock
+        $this->options
             ->expects(self::exactly(2))
             ->method('setTtl')
             ->with(0)
@@ -556,6 +559,11 @@ final class CacheItemPoolDecoratorTest extends TestCase
             ->with(['foo' => 'bar'])
             ->willReturn(['foo' => true]);
 
+        $this->options
+            ->expects(self::once())
+            ->method('getNamespace')
+            ->willReturn('laminascache');
+
         $adapter = $this->getAdapter($storage);
         $storage
             ->expects(self::once())
@@ -571,7 +579,7 @@ final class CacheItemPoolDecoratorTest extends TestCase
 
     public function testClearWithoutNamespaceReturnsTrue(): void
     {
-        $storage = $this->createMockedStorage(null, ['namespace' => '']);
+        $storage = $this->createMockedStorage(new AdapterOptions(['namespace' => '']));
         $adapter = $this->getAdapter($storage);
         $storage
             ->expects(self::once())
@@ -592,7 +600,7 @@ final class CacheItemPoolDecoratorTest extends TestCase
 
     public function testClearEmptyReturnsTrue(): void
     {
-        $storage = $this->createMockedStorage(null, ['namespace' => '']);
+        $storage = $this->createMockedStorage(new AdapterOptions(['namespace' => '']));
         $storage
             ->expects(self::once())
             ->method('flush')
@@ -611,11 +619,17 @@ final class CacheItemPoolDecoratorTest extends TestCase
             ->method('hasItem')
             ->willReturn(false);
 
+        $this->options
+            ->expects(self::once())
+            ->method('getNamespace')
+            ->willReturn('bar');
+
         $item = $adapter->getItem('foo');
         $adapter->saveDeferred($item);
         $this->storage
             ->expects(self::once())
             ->method('clearByNamespace')
+            ->with('bar')
             ->willReturn(true);
 
         $adapter->clear();
@@ -624,7 +638,7 @@ final class CacheItemPoolDecoratorTest extends TestCase
 
     public function testClearRuntimeExceptionReturnsFalse(): void
     {
-        $storage = $this->createMockedStorage(null, ['namespace' => '']);
+        $storage = $this->createMockedStorage(new AdapterOptions(['namespace' => '']));
         $storage
             ->expects(self::once())
             ->method('flush')
@@ -634,7 +648,7 @@ final class CacheItemPoolDecoratorTest extends TestCase
 
     public function testClearByNamespaceReturnsTrue(): void
     {
-        $storage = $this->createMockedStorage(null, ['namespace' => 'laminascache']);
+        $storage = $this->createMockedStorage(new AdapterOptions(['namespace' => 'laminascache']));
         $storage
             ->expects(self::once())
             ->method('clearByNamespace')
@@ -646,7 +660,7 @@ final class CacheItemPoolDecoratorTest extends TestCase
 
     public function testClearByEmptyNamespaceCallsFlush(): void
     {
-        $storage = $this->createMockedStorage(null, ['namespace' => '']);
+        $storage = $this->createMockedStorage(new AdapterOptions(['namespace' => '']));
         $storage
             ->expects(self::once())
             ->method('flush')
@@ -657,7 +671,7 @@ final class CacheItemPoolDecoratorTest extends TestCase
 
     public function testClearByNamespaceRuntimeExceptionReturnsFalse(): void
     {
-        $storage = $this->createMockedStorage(null, ['namespace' => 'laminascache']);
+        $storage = $this->createMockedStorage(new AdapterOptions(['namespace' => 'laminascache']));
         $storage
             ->expects(self::once())
             ->method('clearByNamespace')
@@ -870,36 +884,9 @@ final class CacheItemPoolDecoratorTest extends TestCase
         return new CacheItemPoolDecorator($storage);
     }
 
-    /**
-     * @param array<string,mixed> $capabilities
-     * @return Capabilities&MockObject
-     */
-    private function createCapabilitiesMock(StorageInterface $storage, array $capabilities): Capabilities
+    private function createAdapterOptions(?array $options = null): AdapterOptions
     {
-        return $this
-            ->getMockBuilder(Capabilities::class)
-            ->enableProxyingToOriginalMethods()
-            ->enableOriginalConstructor()
-            ->setConstructorArgs([
-                $storage,
-                new stdClass(),
-                $capabilities,
-            ])->getMock();
-    }
-
-    private function createOptionsMock(?array $options): AdapterOptions
-    {
-        $mock = $this->optionsMock = $this
-            ->getMockBuilder(AdapterOptions::class)
-            ->enableProxyingToOriginalMethods()
-            ->enableOriginalConstructor()
-            ->getMock();
-
-        if ($options) {
-            $mock->setFromArray($options);
-        }
-
-        return $mock;
+        return new AdapterOptions($options);
     }
 
     protected function tearDown(): void
@@ -956,9 +943,9 @@ final class CacheItemPoolDecoratorTest extends TestCase
     {
         $adapter = $this->createMock(FlushableStorageAdapterInterface::class);
         $adapter
-            ->expects(self::exactly(2))
+            ->expects(self::atLeast(3))
             ->method('getCapabilities')
-            ->willReturn(new Capabilities($adapter, new stdClass(), $this->defaultCapabilities));
+            ->willReturn($this->createCapabilities($adapter));
 
         $adapter
             ->expects(self::never())
@@ -992,5 +979,63 @@ final class CacheItemPoolDecoratorTest extends TestCase
             'deletion failed due to hasItems states the key still exists'       => [true, false],
             'deletion successful due to hasItems states the key does not exist' => [false, true],
         ];
+    }
+
+    public function testWillUsePcreMaximumQuantifierLengthIfAdapterAllowsMoreThanThat(): void
+    {
+        $storage      = $this->createMock(FlushableStorageAdapterInterface::class);
+        $capabilities = $this->createCapabilities(
+            $storage,
+            null,
+            true,
+            60,
+            SimpleCacheDecorator::$PCRE_MAXIMUM_QUANTIFIER_LENGTH
+        );
+
+        $storage
+            ->method('getCapabilities')
+            ->willReturn($capabilities);
+
+        $decorator = new CacheItemPoolDecorator($storage);
+        $key       = str_repeat('a', CacheItemPoolDecorator::$PCRE_MAXIMUM_QUANTIFIER_LENGTH);
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(sprintf(
+            'key is too long. Must be no more than %d characters',
+            CacheItemPoolDecorator::$PCRE_MAXIMUM_QUANTIFIER_LENGTH - 1
+        ));
+        $decorator->getItem($key);
+    }
+
+    public function testPcreMaximumQuantifierLengthWontResultInCompilationError(): void
+    {
+        self::assertEquals(
+            0,
+            preg_match(
+                sprintf(
+                    '/^.{%d,}$/',
+                    CacheItemPoolDecorator::$PCRE_MAXIMUM_QUANTIFIER_LENGTH
+                ),
+                ''
+            )
+        );
+    }
+
+    private function createCapabilities(
+        StorageInterface $storage,
+        ?array $supportedDataTypes = null,
+        bool $staticTtl = true,
+        int $minTtl = 1,
+        int $maxKeyLength = -1,
+        bool $useRequestTime = false,
+        bool $lockOnExpire = false
+    ): Capabilities {
+        return new Capabilities($storage, new stdClass(), [
+            'supportedDatatypes' => $supportedDataTypes ?? $this->requiredTypes,
+            'staticTtl'          => $staticTtl,
+            'minTtl'             => $minTtl,
+            'maxKeyLength'       => $maxKeyLength,
+            'useRequestTime'     => $useRequestTime,
+            'lockOnExpire'       => $lockOnExpire,
+        ]);
     }
 }

--- a/test/Psr/SimpleCache/SimpleCacheDecoratorTest.php
+++ b/test/Psr/SimpleCache/SimpleCacheDecoratorTest.php
@@ -1139,7 +1139,7 @@ class SimpleCacheDecoratorTest extends TestCase
             null,
             true,
             60,
-            SimpleCacheDecorator::PCRE_MAXIMUM_QUANTIFIER_LENGTH
+            SimpleCacheDecorator::$PCRE_MAXIMUM_QUANTIFIER_LENGTH
         );
 
         $storage
@@ -1147,11 +1147,11 @@ class SimpleCacheDecoratorTest extends TestCase
             ->willReturn($capabilities);
 
         $decorator = new SimpleCacheDecorator($storage);
-        $key       = str_repeat('a', SimpleCacheDecorator::PCRE_MAXIMUM_QUANTIFIER_LENGTH);
+        $key       = str_repeat('a', SimpleCacheDecorator::$PCRE_MAXIMUM_QUANTIFIER_LENGTH);
         $this->expectException(SimpleCacheInvalidArgumentException::class);
         $this->expectExceptionMessage(sprintf(
             'key is too long. Must be no more than %d characters',
-            SimpleCacheDecorator::PCRE_MAXIMUM_QUANTIFIER_LENGTH - 1
+            SimpleCacheDecorator::$PCRE_MAXIMUM_QUANTIFIER_LENGTH - 1
         ));
         $decorator->has($key);
     }
@@ -1163,7 +1163,7 @@ class SimpleCacheDecoratorTest extends TestCase
             preg_match(
                 sprintf(
                     '/^.{%d,}$/',
-                    SimpleCacheDecorator::PCRE_MAXIMUM_QUANTIFIER_LENGTH
+                    SimpleCacheDecorator::$PCRE_MAXIMUM_QUANTIFIER_LENGTH
                 ),
                 ''
             )

--- a/test/Psr/SimpleCache/SimpleCacheDecoratorTest.php
+++ b/test/Psr/SimpleCache/SimpleCacheDecoratorTest.php
@@ -1127,7 +1127,7 @@ class SimpleCacheDecoratorTest extends TestCase
             ->willReturn($capabilities);
 
         $this->expectException(SimpleCacheInvalidArgumentException::class);
-        $this->expectExceptionMessage('does not fulfill the minimum requirements for PSR-16');
+        $this->expectExceptionMessage('does not fulfill the minimum requirements');
 
         new SimpleCacheDecorator($storage);
     }

--- a/test/Psr/SimpleCache/SimpleCacheDecoratorTest.php
+++ b/test/Psr/SimpleCache/SimpleCacheDecoratorTest.php
@@ -1139,7 +1139,7 @@ class SimpleCacheDecoratorTest extends TestCase
             null,
             true,
             60,
-            SimpleCacheDecorator::$PCRE_MAXIMUM_QUANTIFIER_LENGTH
+            SimpleCacheDecorator::$pcreMaximumQuantifierLength
         );
 
         $storage
@@ -1147,11 +1147,11 @@ class SimpleCacheDecoratorTest extends TestCase
             ->willReturn($capabilities);
 
         $decorator = new SimpleCacheDecorator($storage);
-        $key       = str_repeat('a', SimpleCacheDecorator::$PCRE_MAXIMUM_QUANTIFIER_LENGTH);
+        $key       = str_repeat('a', SimpleCacheDecorator::$pcreMaximumQuantifierLength);
         $this->expectException(SimpleCacheInvalidArgumentException::class);
         $this->expectExceptionMessage(sprintf(
             'key is too long. Must be no more than %d characters',
-            SimpleCacheDecorator::$PCRE_MAXIMUM_QUANTIFIER_LENGTH - 1
+            SimpleCacheDecorator::$pcreMaximumQuantifierLength - 1
         ));
         $decorator->has($key);
     }
@@ -1163,7 +1163,7 @@ class SimpleCacheDecoratorTest extends TestCase
             preg_match(
                 sprintf(
                     '/^.{%d,}$/',
-                    SimpleCacheDecorator::$PCRE_MAXIMUM_QUANTIFIER_LENGTH
+                    SimpleCacheDecorator::$pcreMaximumQuantifierLength
                 ),
                 ''
             )


### PR DESCRIPTION
<!--
Fill in the relevant information below to help triage your issue.

Pick the target branch based on the following criteria:
  * Documentation improvement: master branch
  * Bugfix: master branch
  * QA improvement (additional tests, CS fixes, etc.) that does not change code
    behavior: master branch
  * New feature, or refactor of existing code: develop branch

You MUST provide a signoff in your commits for us to be able to accept your
patch; you can do this by providing either the --signoff or -s flag when using
"git commit". Please see the project contributing guide and
https://developercertificate.org for details.
-->

|    Q          |   A
|-------------- | ------
| Documentation | yes
| Bugfix        | no
| BC Break      | yes
| New Feature   | yes

### Description

<!--
Tell us about why this change is necessary:
- Are you fixing a bug or providing a failing unit test to demonstrate a bug?
  - How do you reproduce it?
  - What did you expect to happen?
  - What actually happened?
  - TARGET THE master BRANCH

- Are you adding documentation?
  - TARGET THE master BRANCH

- Are you providing a QA improvement (additional tests, CS fixes, etc.) that
  does not change behavior?
  - Explain why the changes are necessary
  - TARGET THE master BRANCH

- Are you fixing a BC Break?
  - How do you reproduce it?
  - What was the previous behavior?
  - What is the current behavior?
  - TARGET THE master BRANCH

- Are you adding something the library currently does not support?
  - Why should it be added?
  - What will it enable?
  - How will the code be used?
  - TARGET THE develop BRANCH

- Are you refactoring code?
  - Why do you feel the refactor is necessary?
  - What types of refactoring are you doing?
  - TARGET THE develop BRANCH
-->

This PR adds the maximum cache key length validation feature which was already part of the `PSR-16` `SimpleCacheDecorator`.
Since both PSR-6 and PSR-16 have the same requirements regarding cache key length, the logic was extract to a dedicated (`internal`) `MaximumKeyLength`-Trait.

Since this validation was not part of the `CacheItemPoolDecorator` before, this is supposed to be a BC break.

----

Besides this, I've also marked the `Laminas\Cache\Psr\SerializationTrait` as `internal`.

----

Fixes #156 