### PR TITLE
Documentation: Fix adapter name configuration key

### DIFF
--- a/docs/book/v3/storage/adapter.md
+++ b/docs/book/v3/storage/adapter.md
@@ -52,7 +52,7 @@ $cache = $storageFactory->create(
 
 // Via array configuration:
 $cache = $storageFactory->createFromArrayConfiguration([
-    'adapter' => 'apcu',
+    'name' => 'apcu',
     'options' => ['ttl' => 3600],
     'plugins' => [
         [


### PR DESCRIPTION
<!--
Fill in the relevant information below to help triage your issue.

Pick the target branch based on the following criteria:
  * Documentation improvement: master branch
  * Bugfix: master branch
  * QA improvement (additional tests, CS fixes, etc.) that does not change code
    behavior: master branch
  * New feature, or refactor of existing code: develop branch

You MUST provide a signoff in your commits for us to be able to accept your
patch; you can do this by providing either the --signoff or -s flag when using
"git commit". Please see the project contributing guide and
https://developercertificate.org for details.
-->

|    Q          |   A
|-------------- | ------
| Documentation | yes
| Bugfix        | no
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description

<!--
Tell us about why this change is necessary:
- Are you fixing a bug or providing a failing unit test to demonstrate a bug?
  - How do you reproduce it?
  - What did you expect to happen?
  - What actually happened?
  - TARGET THE master BRANCH

- Are you adding documentation?
  - TARGET THE master BRANCH

- Are you providing a QA improvement (additional tests, CS fixes, etc.) that
  does not change behavior?
  - Explain why the changes are necessary
  - TARGET THE master BRANCH

- Are you fixing a BC Break?
  - How do you reproduce it?
  - What was the previous behavior?
  - What is the current behavior?
  - TARGET THE master BRANCH

- Are you adding something the library currently does not support?
  - Why should it be added?
  - What will it enable?
  - How will the code be used?
  - TARGET THE develop BRANCH

- Are you refactoring code?
  - Why do you feel the refactor is necessary?
  - What types of refactoring are you doing?
  - TARGET THE develop BRANCH
-->
In the quick start https://docs.laminas.dev/laminas-cache/v3/storage/adapter/#quick-start section of the docs, it suggests the normalized configuration array requires the adapter name passed as the value to the `adapter` key. Looking at the source https://github.com/laminas/laminas-cache/blob/2bcf8645a9e7a12f6e0332bd9d8be6c228616e55/src/Service/StorageAdapterFactory.php#L39 suggests this should be `name` instead, which is what works currently when testing this.

This PR updates the documentation to reflect the correct key name.