### PR TITLE
Allow `adapter` as configuration key when using `StoragePluginFactoryInterface`

### DIFF
--- a/src/Service/StoragePluginFactory.php
+++ b/src/Service/StoragePluginFactory.php
@@ -24,7 +24,8 @@ final class StoragePluginFactory implements StoragePluginFactoryInterface
 
     public function createFromArrayConfiguration(array $configuration): PluginInterface
     {
-        $name    = $configuration['name'];
+        $name = $configuration['adapter'] ?? $configuration['name'] ?? null;
+        Assert::stringNotEmpty($name, 'Configuration must contain a "adapter" key.');
         $options = $configuration['options'] ?? [];
 
         return $this->create($name, $options);
@@ -41,8 +42,15 @@ final class StoragePluginFactory implements StoragePluginFactoryInterface
     {
         try {
             Assert::isNonEmptyMap($configuration, 'Configuration must be a non-empty array.');
-            Assert::keyExists($configuration, 'name', 'Configuration must contain a "name" key.');
-            Assert::stringNotEmpty($configuration['name'], 'Plugin "name" has to be a non-empty string.');
+            if (! isset($configuration['name']) && ! isset($configuration['adapter'])) {
+                throw new PhpInvalidArgumentException('Configuration must contain a "adapter" key.');
+            }
+
+            Assert::stringNotEmpty(
+                $configuration['adapter'] ?? $configuration['name'],
+                'Plugin "adapter" has to be a non-empty string.'
+            );
+
             Assert::nullOrIsMap(
                 $configuration['options'] ?? null,
                 'Plugin "options" must be an array with string keys.'

--- a/src/Service/StoragePluginFactoryInterface.php
+++ b/src/Service/StoragePluginFactoryInterface.php
@@ -8,7 +8,7 @@ use Laminas\Cache\Exception\InvalidArgumentException;
 use Laminas\Cache\Storage\Plugin\PluginInterface;
 
 /**
- * @psalm-type PluginArrayConfigurationType = array{name:non-empty-string,options?:array<string,mixed>}
+ * @psalm-type PluginArrayConfigurationType = array{name:non-empty-string,options?:array<string,mixed>}|array{adapter:non-empty-string,options?:array<string,mixed>}
  */
 interface StoragePluginFactoryInterface
 {

--- a/test/Service/StoragePluginFactoryTest.php
+++ b/test/Service/StoragePluginFactoryTest.php
@@ -37,23 +37,37 @@ final class StoragePluginFactoryTest extends TestCase
             'Configuration must be a non-empty array',
         ];
 
-        yield 'missing name' => [
+        yield 'missing adapter' => [
             ['options' => []],
-            'Configuration must contain a "name" key',
+            'Configuration must contain a "adapter" key',
         ];
 
-        yield 'empty name' => [
-            ['name' => ''],
-            'Plugin "name" has to be a non-empty string',
+        yield 'empty adapter name' => [
+            ['adapter' => ''],
+            'Plugin "adapter" has to be a non-empty string',
         ];
 
         yield 'invalid options' => [
-            ['name' => 'foo', 'options' => 'bar'],
+            ['adapter' => 'foo', 'options' => 'bar'],
             'Plugin "options" must be an array with string keys',
         ];
     }
 
     public function testWillCreatePluginFromArrayConfiguration(): void
+    {
+        $plugin = $this->createMock(PluginInterface::class);
+
+        $this->plugins
+            ->expects(self::once())
+            ->method('build')
+            ->with('foo')
+            ->willReturn($plugin);
+
+        $createdPlugin = $this->factory->createFromArrayConfiguration(['adapter' => 'foo']);
+        self::assertSame($plugin, $createdPlugin);
+    }
+
+    public function testWillCreatePluginFromDeprecatedArrayConfiguration(): void
     {
         $plugin = $this->createMock(PluginInterface::class);
 
@@ -78,7 +92,7 @@ final class StoragePluginFactoryTest extends TestCase
             ->willReturn($plugin);
 
         $createdPlugin = $this->factory->createFromArrayConfiguration(
-            ['name' => 'foo', 'options' => ['bar' => 'baz']]
+            ['adapter' => 'foo', 'options' => ['bar' => 'baz']]
         );
 
         self::assertSame($plugin, $createdPlugin);
@@ -131,7 +145,7 @@ final class StoragePluginFactoryTest extends TestCase
     {
         $this->expectNotToPerformAssertions();
         $this->factory->assertValidConfigurationStructure([
-            'name'    => 'foo',
+            'adapter' => 'foo',
             'options' => ['bar' => 'baz'],
         ]);
     }


### PR DESCRIPTION
<!--
Fill in the relevant information below to help triage your issue.

Pick the target branch based on the following criteria:
  * Documentation improvement: master branch
  * Bugfix: master branch
  * QA improvement (additional tests, CS fixes, etc.) that does not change code
    behavior: master branch
  * New feature, or refactor of existing code: develop branch

You MUST provide a signoff in your commits for us to be able to accept your
patch; you can do this by providing either the --signoff or -s flag when using
"git commit". Please see the project contributing guide and
https://developercertificate.org for details.
-->

|    Q          |   A
|-------------- | ------
| Bugfix        | no
| BC Break      | no
| New Feature   | yes

### Description

<!--
Tell us about why this change is necessary:
- Are you fixing a bug or providing a failing unit test to demonstrate a bug?
  - How do you reproduce it?
  - What did you expect to happen?
  - What actually happened?
  - TARGET THE master BRANCH

- Are you adding documentation?
  - TARGET THE master BRANCH

- Are you providing a QA improvement (additional tests, CS fixes, etc.) that
  does not change behavior?
  - Explain why the changes are necessary
  - TARGET THE master BRANCH

- Are you fixing a BC Break?
  - How do you reproduce it?
  - What was the previous behavior?
  - What is the current behavior?
  - TARGET THE master BRANCH

- Are you adding something the library currently does not support?
  - Why should it be added?
  - What will it enable?
  - How will the code be used?
  - TARGET THE develop BRANCH

- Are you refactoring code?
  - Why do you feel the refactor is necessary?
  - What types of refactoring are you doing?
  - TARGET THE develop BRANCH
-->

In v2.12.0, we provided a normalized array structure along with a configuration check command. When a project is being migrated from latest v2 version to v3, it will still break due to an incompatible configuration. This was changed in v3 and was not backported to v2 before releasing v3.

With this patch, the `name` configuration key will be deprecated in favor of the `adapter` configuration key to ensure better backwards compatibility. `adapter` is also used in documentation as outlined in #179 and thus, this could also be treated as a bugfix.