### PR TITLE
Revert changes made for `adapter` name from `StoragePluginFactoryInterface` and apply to `StorageAdapterFactoryInterface` instead

### DIFF
--- a/src/Service/StorageAdapterFactory.php
+++ b/src/Service/StorageAdapterFactory.php
@@ -36,7 +36,8 @@ final class StorageAdapterFactory implements StorageAdapterFactoryInterface
 
     public function createFromArrayConfiguration(array $configuration): StorageInterface
     {
-        $adapterName    = $configuration['name'];
+        $adapterName = $configuration['adapter'] ?? $configuration['name'] ?? null;
+        Assert::stringNotEmpty($adapterName, 'Configuration must contain a "adapter" key.');
         $adapterOptions = $configuration['options'] ?? [];
         $plugins        = $configuration['plugins'] ?? [];
 

--- a/src/Service/StorageAdapterFactoryInterface.php
+++ b/src/Service/StorageAdapterFactoryInterface.php
@@ -17,6 +17,10 @@ use Laminas\Cache\Storage\StorageInterface;
  *     name:non-empty-string,
  *     options?:array<string,mixed>,
  *     plugins?: list<PluginArrayConfigurationWithPriorityType>
+ * }|array{
+ *     adapter:non-empty-string,
+ *     options?:array<string,mixed>,
+ *     plugins?: list<PluginArrayConfigurationWithPriorityType>
  * }
  */
 interface StorageAdapterFactoryInterface

--- a/src/Service/StoragePluginFactory.php
+++ b/src/Service/StoragePluginFactory.php
@@ -24,8 +24,7 @@ final class StoragePluginFactory implements StoragePluginFactoryInterface
 
     public function createFromArrayConfiguration(array $configuration): PluginInterface
     {
-        $name = $configuration['adapter'] ?? $configuration['name'] ?? null;
-        Assert::stringNotEmpty($name, 'Configuration must contain a "adapter" key.');
+        $name    = $configuration['name'];
         $options = $configuration['options'] ?? [];
 
         return $this->create($name, $options);
@@ -42,15 +41,8 @@ final class StoragePluginFactory implements StoragePluginFactoryInterface
     {
         try {
             Assert::isNonEmptyMap($configuration, 'Configuration must be a non-empty array.');
-            if (! isset($configuration['name']) && ! isset($configuration['adapter'])) {
-                throw new PhpInvalidArgumentException('Configuration must contain a "adapter" key.');
-            }
-
-            Assert::stringNotEmpty(
-                $configuration['adapter'] ?? $configuration['name'],
-                'Plugin "adapter" has to be a non-empty string.'
-            );
-
+            Assert::keyExists($configuration, 'name', 'Configuration must contain a "name" key.');
+            Assert::stringNotEmpty($configuration['name'], 'Plugin "name" has to be a non-empty string.');
             Assert::nullOrIsMap(
                 $configuration['options'] ?? null,
                 'Plugin "options" must be an array with string keys.'

--- a/src/Service/StoragePluginFactoryInterface.php
+++ b/src/Service/StoragePluginFactoryInterface.php
@@ -8,7 +8,7 @@ use Laminas\Cache\Exception\InvalidArgumentException;
 use Laminas\Cache\Storage\Plugin\PluginInterface;
 
 /**
- * @psalm-type PluginArrayConfigurationType = array{name:non-empty-string,options?:array<string,mixed>}|array{adapter:non-empty-string,options?:array<string,mixed>}
+ * @psalm-type PluginArrayConfigurationType = array{name:non-empty-string,options?:array<string,mixed>}
  */
 interface StoragePluginFactoryInterface
 {

--- a/test/Service/StorageAdapterFactoryTest.php
+++ b/test/Service/StorageAdapterFactoryTest.php
@@ -139,6 +139,30 @@ final class StorageAdapterFactoryTest extends TestCase
     }
 
     /**
+     * @psalm-param non-empty-string $adapterName
+     * @param array<string,mixed> $adapterConfiguration
+     * @dataProvider storageConfigurations
+     */
+    public function testWillCreateStorageFromArrayConfigurationAndAdapterKey(
+        string $adapterName,
+        array $adapterConfiguration
+    ): void {
+        $adapterMock = $this->createMock(AbstractAdapter::class);
+        $this->adapters
+            ->expects(self::once())
+            ->method('build')
+            ->with($adapterName, $adapterConfiguration)
+            ->willReturn($adapterMock);
+
+        $adapter = $this->factory->createFromArrayConfiguration([
+            'adapter' => $adapterName,
+            'options' => $adapterConfiguration,
+        ]);
+
+        self::assertSame($adapterMock, $adapter);
+    }
+
+    /**
      * @psalm-param list<PluginArrayConfigurationWithPriorityType> $plugins
      * @dataProvider pluginConfigurations
      */

--- a/test/Service/StoragePluginFactoryTest.php
+++ b/test/Service/StoragePluginFactoryTest.php
@@ -37,37 +37,23 @@ final class StoragePluginFactoryTest extends TestCase
             'Configuration must be a non-empty array',
         ];
 
-        yield 'missing adapter' => [
+        yield 'missing name' => [
             ['options' => []],
-            'Configuration must contain a "adapter" key',
+            'Configuration must contain a "name" key',
         ];
 
-        yield 'empty adapter name' => [
-            ['adapter' => ''],
-            'Plugin "adapter" has to be a non-empty string',
+        yield 'empty name' => [
+            ['name' => ''],
+            'Plugin "name" has to be a non-empty string',
         ];
 
         yield 'invalid options' => [
-            ['adapter' => 'foo', 'options' => 'bar'],
+            ['name' => 'foo', 'options' => 'bar'],
             'Plugin "options" must be an array with string keys',
         ];
     }
 
     public function testWillCreatePluginFromArrayConfiguration(): void
-    {
-        $plugin = $this->createMock(PluginInterface::class);
-
-        $this->plugins
-            ->expects(self::once())
-            ->method('build')
-            ->with('foo')
-            ->willReturn($plugin);
-
-        $createdPlugin = $this->factory->createFromArrayConfiguration(['adapter' => 'foo']);
-        self::assertSame($plugin, $createdPlugin);
-    }
-
-    public function testWillCreatePluginFromDeprecatedArrayConfiguration(): void
     {
         $plugin = $this->createMock(PluginInterface::class);
 
@@ -92,7 +78,7 @@ final class StoragePluginFactoryTest extends TestCase
             ->willReturn($plugin);
 
         $createdPlugin = $this->factory->createFromArrayConfiguration(
-            ['adapter' => 'foo', 'options' => ['bar' => 'baz']]
+            ['name' => 'foo', 'options' => ['bar' => 'baz']]
         );
 
         self::assertSame($plugin, $createdPlugin);
@@ -145,7 +131,7 @@ final class StoragePluginFactoryTest extends TestCase
     {
         $this->expectNotToPerformAssertions();
         $this->factory->assertValidConfigurationStructure([
-            'adapter' => 'foo',
+            'name'    => 'foo',
             'options' => ['bar' => 'baz'],
         ]);
     }


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description

Looks like fix #182 introduced by @boesing is wrong. This change should be applied to Adapters, not plugins. That's why https://github.com/doctrine/DoctrineModule/pull/753#issuecomment-971768119 still fails.