### PR TITLE
Fix storage adapter factory assertion with adapter key

### DIFF
--- a/src/Service/StorageAdapterFactory.php
+++ b/src/Service/StorageAdapterFactory.php
@@ -13,6 +13,7 @@ use Webmozart\Assert\Assert;
 
 use function assert;
 use function get_class;
+use function is_string;
 use function sprintf;
 
 /**
@@ -77,15 +78,21 @@ final class StorageAdapterFactory implements StorageAdapterFactoryInterface
     {
         try {
             Assert::isNonEmptyMap($configuration, 'Configuration must be a non-empty array.');
-            Assert::keyExists($configuration, 'name', 'Configuration must contain a "name" key.');
-            Assert::stringNotEmpty($configuration['name'], 'Storage "name" has to be a non-empty string.');
+
+            $adapter = $configuration['adapter'] ?? $configuration['name'] ?? null;
+
+            if (! is_string($adapter)) {
+                throw new InvalidArgumentException('Configuration must contain a "adapter" key.');
+            }
+
+            Assert::stringNotEmpty($adapter, 'Storage "adapter" has to be a non-empty string.');
             Assert::nullOrIsMap(
                 $configuration['options'] ?? null,
                 'Storage "options" must be an array with string keys.'
             );
             if (isset($configuration['plugins'])) {
                 Assert::isList($configuration['plugins'], 'Storage "plugins" must be a list of plugin configurations.');
-                $this->assertValidPluginConfigurationStructure($configuration['name'], $configuration['plugins']);
+                $this->assertValidPluginConfigurationStructure($adapter, $configuration['plugins']);
             }
         } catch (InvalidArgumentException $exception) {
             throw new Exception\InvalidArgumentException($exception->getMessage(), 0, $exception);

--- a/test/Service/StorageAdapterFactoryTest.php
+++ b/test/Service/StorageAdapterFactoryTest.php
@@ -87,21 +87,21 @@ final class StorageAdapterFactoryTest extends TestCase
 
         yield 'missing name' => [
             ['options' => []],
-            'Configuration must contain a "name" key',
+            'Configuration must contain a "adapter" key',
         ];
 
         yield 'empty name' => [
-            ['name' => ''],
-            'Storage "name" has to be a non-empty string',
+            ['adapter' => ''],
+            'Storage "adapter" has to be a non-empty string',
         ];
 
         yield 'invalid options' => [
-            ['name' => 'foo', 'options' => 'bar'],
+            ['adapter' => 'foo', 'options' => 'bar'],
             'Storage "options" must be an array with string keys',
         ];
 
         yield 'invalid plugin configuration' => [
-            ['name' => 'foo', 'plugins' => ['bar']],
+            ['adapter' => 'foo', 'plugins' => ['bar']],
             'All plugin configurations are expected to be an array',
         ];
     }
@@ -119,7 +119,7 @@ final class StorageAdapterFactoryTest extends TestCase
      * @param array<string,mixed> $adapterConfiguration
      * @dataProvider storageConfigurations
      */
-    public function testWillCreateStorageFromArrayConfiguration(
+    public function testWillCreateStorageFromArrayConfigurationWithDeprecatedNameKey(
         string $adapterName,
         array $adapterConfiguration
     ): void {
@@ -143,7 +143,7 @@ final class StorageAdapterFactoryTest extends TestCase
      * @param array<string,mixed> $adapterConfiguration
      * @dataProvider storageConfigurations
      */
-    public function testWillCreateStorageFromArrayConfigurationAndAdapterKey(
+    public function testWillCreateStorageFromArrayConfiguration(
         string $adapterName,
         array $adapterConfiguration
     ): void {
@@ -250,7 +250,7 @@ final class StorageAdapterFactoryTest extends TestCase
             ->willThrowException(new InvalidArgumentException('ERROR FROM PLUGIN CONFIGURATION ASSERTION'));
 
         $this->factory->assertValidConfigurationStructure([
-            'name'    => 'foo',
+            'adapter' => 'foo',
             'plugins' => [
                 ['name' => ''],
             ],
@@ -269,7 +269,7 @@ final class StorageAdapterFactoryTest extends TestCase
             ->method('assertValidConfigurationStructure');
 
         $this->factory->assertValidConfigurationStructure([
-            'name'    => 'bar',
+            'adapter' => 'bar',
             'plugins' => [
                 ['name' => 'baz', 'priority' => true],
             ],
@@ -280,7 +280,7 @@ final class StorageAdapterFactoryTest extends TestCase
     {
         $this->expectNotToPerformAssertions();
         $this->factory->assertValidConfigurationStructure([
-            'name'    => 'foo',
+            'adapter' => 'foo',
             'options' => ['bar' => 'baz'],
         ]);
     }


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description

Fixes missing change in validate method for configuration introduced in #183
