### PR TITLE
Replace `stella-maris/clock` with `psr/clock`

### DIFF
--- a/.laminas-ci.json
+++ b/.laminas-ci.json
@@ -1,12 +1,10 @@
 {
-    "ignore_php_platform_requirements": {
-        "8.2": true
-    },
     "extensions": [
         "apcu"
     ],
     "ini": [
         "apc.enabled=1",
         "apc.enable_cli=1"
-    ]
+    ],
+    "backwardCompatibilityCheck": true
 }

--- a/.laminas-ci/pre-install.sh
+++ b/.laminas-ci/pre-install.sh
@@ -2,8 +2,7 @@
 
 WORKING_DIRECTORY=$2
 JOB=$3
-PHP_VERSION=$(echo "${JOB}" | jq -r '.php')
-
+PHP_VERSION=$(php -nr "echo PHP_MAJOR_VERSION . '.' . PHP_MINOR_VERSION;")
 
 if [ ! -z "$GITHUB_BASE_REF" ] && [[ "$GITHUB_BASE_REF" =~ ^[0-9]+\.[0-9] ]]; then
   readarray -td. TARGET_BRANCH_VERSION_PARTS <<<"${GITHUB_BASE_REF}.";

--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,7 @@
         "laminas/laminas-stdlib": "^3.6",
         "psr/cache": "^1.0",
         "psr/simple-cache": "^1.0",
-        "stella-maris/clock": "^0.1.5",
+        "psr/clock": "^1.0",
         "webmozart/assert": "^1.9"
     },
     "require-dev": {
@@ -61,7 +61,8 @@
         "vimeo/psalm": "^5.4"
     },
     "conflict": {
-        "symfony/console": "<5.1"
+        "symfony/console": "<5.1",
+        "stella-maris/clock": "<0.1.7"
     },
     "provide": {
         "psr/cache-implementation": "1.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2af9913a79f72a9aedd445d0deeacebf",
+    "content-hash": "295bfbb0011bdabd9ee9e7ab205903e7",
     "packages": [
         {
             "name": "laminas/laminas-cache-storage-adapter-memory",
@@ -486,53 +486,6 @@
                 "source": "https://github.com/php-fig/simple-cache/tree/master"
             },
             "time": "2017-10-23T01:57:42+00:00"
-        },
-        {
-            "name": "stella-maris/clock",
-            "version": "0.1.7",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/stella-maris-solutions/clock.git",
-                "reference": "fa23ce16019289a18bb3446fdecd45befcdd94f8"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/stella-maris-solutions/clock/zipball/fa23ce16019289a18bb3446fdecd45befcdd94f8",
-                "reference": "fa23ce16019289a18bb3446fdecd45befcdd94f8",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.0|^8.0",
-                "psr/clock": "^1.0"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "StellaMaris\\Clock\\": "src"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Andreas Heigl",
-                    "role": "Maintainer"
-                }
-            ],
-            "description": "A pre-release of the proposed PSR-20 Clock-Interface",
-            "homepage": "https://gitlab.com/stella-maris/clock",
-            "keywords": [
-                "clock",
-                "datetime",
-                "point in time",
-                "psr20"
-            ],
-            "support": {
-                "source": "https://github.com/stella-maris-solutions/clock/tree/0.1.7"
-            },
-            "time": "2022-11-25T16:15:06+00:00"
         },
         {
             "name": "webmozart/assert",

--- a/src/Psr/CacheItemPool/CacheItem.php
+++ b/src/Psr/CacheItemPool/CacheItem.php
@@ -6,7 +6,7 @@ use DateInterval;
 use DateTimeImmutable;
 use DateTimeInterface;
 use Psr\Cache\CacheItemInterface;
-use StellaMaris\Clock\ClockInterface;
+use Psr\Clock\ClockInterface;
 
 use function gettype;
 use function is_int;

--- a/src/Psr/CacheItemPool/CacheItemPoolDecorator.php
+++ b/src/Psr/CacheItemPool/CacheItemPoolDecorator.php
@@ -11,7 +11,7 @@ use Laminas\Cache\Storage\FlushableInterface;
 use Laminas\Cache\Storage\StorageInterface;
 use Psr\Cache\CacheItemInterface;
 use Psr\Cache\CacheItemPoolInterface;
-use StellaMaris\Clock\ClockInterface;
+use Psr\Clock\ClockInterface;
 
 use function array_diff;
 use function array_diff_key;

--- a/test/Psr/CacheItemPool/CacheItemPoolDecoratorTest.php
+++ b/test/Psr/CacheItemPool/CacheItemPoolDecoratorTest.php
@@ -22,8 +22,8 @@ use LaminasTest\Cache\Psr\TestAsset\FlushableNamespaceStorageInterface;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Cache\CacheItemInterface;
+use Psr\Clock\ClockInterface;
 use stdClass;
-use StellaMaris\Clock\ClockInterface;
 use Throwable;
 
 use function array_keys;

--- a/test/Psr/CacheItemPool/CacheItemTest.php
+++ b/test/Psr/CacheItemPool/CacheItemTest.php
@@ -11,7 +11,7 @@ use DateTimeZone;
 use Laminas\Cache\Psr\CacheItemPool\CacheItem;
 use Laminas\Cache\Psr\CacheItemPool\InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
-use StellaMaris\Clock\ClockInterface;
+use Psr\Clock\ClockInterface;
 
 use function date_default_timezone_get;
 use function date_default_timezone_set;


### PR DESCRIPTION
<!--
Fill in the relevant information below to help triage your issue.

Pick the target branch based on the following criteria:
  * Documentation improvement: default X.Y.z branch or the oldest support X.Y.z
  * Bugfix: default X.Y.z branch or the oldest support X.Y.z
  * QA improvement (additional tests, CS fixes, etc.) that does not change code
    behavior: default X.Y.z branch or the oldest support X.Y.z
  * New feature, or refactor of existing code: develop branch

You MUST provide a signoff in your commits for us to be able to accept your
patch; you can do this by providing either the --signoff or -s flag when using
"git commit". Please see the project contributing guide and
https://developercertificate.org for details.
-->

|    Q          |   A
|-------------- | ------
| QA            | yes

### Description

<!--
Tell us about why this change is necessary:
- Are you fixing a bug or providing a failing unit test to demonstrate a bug?
  - How do you reproduce it?
  - What did you expect to happen?
  - What actually happened?
  - TARGET THE default X.Y.z branch or the oldest support X.Y.z

- Are you adding documentation?
  - TARGET THE default X.Y.z branch or the oldest support X.Y.z

- Are you providing a QA improvement (additional tests, CS fixes, etc.) that
  does not change behavior?
  - Explain why the changes are necessary
  - TARGET THE default X.Y.z branch or the oldest support X.Y.z

- Are you fixing a BC Break?
  - How do you reproduce it?
  - What was the previous behavior?
  - What is the current behavior?
  - TARGET THE default X.Y.z branch or the oldest support X.Y.z

- Are you adding something the library currently does not support?
  - Why should it be added?
  - What will it enable?
  - How will the code be used?
  - TARGET THE develop BRANCH

- Are you refactoring code?
  - Why do you feel the refactor is necessary?
  - What types of refactoring are you doing?
  - TARGET THE develop BRANCH
-->

With [3.4.0](https://github.com/laminas/laminas-cache/releases/tag/3.4.0), the pre PSR-20 `ClockInterface` was introduced to this package via the dependency of `stella-maris/clock`. With 0.1.7, the project is extending `PSR-20` and thus, can be replaced as long as we conflict with versions lower than `0.1.7`.

This PR updates the code to consume PSR interface rather than working group version.