### PR TITLE
Sets current version in MkDocs configuration file

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -63,8 +63,9 @@ extra:
     installation:
         config_provider_class: 'Laminas\Cache\ConfigProvider'
         module_class: 'Laminas\Cache\Module'
-    current_version: v3
+    current_version: v4
     versions:
+        - v4
         - v3
         - v2
     show_special_homepage: true


### PR DESCRIPTION
> # Versioned Contents
> 
> A documentation can be separated into different versions.
> Several steps are necessary for this.
> 
> ## Usage
> 
> 1. A separate subfolder is necessary for each version.
>     * `docs`
>       * `book`
>         * `v3`
>           * `introduction.md`
>           * `installation.md`
>           * …
>         * `v2`
>           * `introduction.md`
>           * `installation.md`
>           * …
>         * `index.md`
> 1. Extend the `nav` section of the MkDocs configuration file and a new section must be created for each version.
>     Add the related navigation entries in these sections.
>     ```yaml
>     nav:
>         - Home: index.md
>         - v3:
>             - Introduction: v3/introduction.md
>             - Installation: v3/installation.md
>             - …
>         - v2:
>             - Introduction: v2/introduction.md
>             - Installation: v2/installation.md
>             - …
>     ```
> 1. Extend the `extra` section of the MkDocs configuration file to add all available versions and the last / current version:
>     ```yaml
>     extra:
>         current_version: v3
>         versions:
>             - v3
>             - v2
>     ```