### PR TITLE
Merge release 3.12.2 into 4.0.x 

### DIFF
--- a/docs/book/v3/storage/adapter.md
+++ b/docs/book/v3/storage/adapter.md
@@ -796,17 +796,18 @@ Capability | Value
 
 ### Adapter Specific Options
 
-Name | Data Type | Default Value | Description
----- | --------- | ------------- | -----------
-`lib_options` | `array` | `[]` | Associative array of Redis options where the array key is the options constant value (see `RedisCluster::OPT_*` [constants](https://github.com/JetBrains/phpstorm-stubs/blob/master/redis/RedisCluster.php) for details).
-`namespace_separator` | `string` | ":" | A separator for the namespace and prefix.
-`password` | `string` | "" | Password to authenticate with Redis server
-`name` | `string` | "" | Name to determine configuration from [php.ini](https://github.com/phpredis/phpredis/blob/develop/cluster.markdown#loading-a-cluster-configuration-by-name) (**MUST NOT** be combined with `seeds`)
-`seeds` | `array` | `[]` | List of strings containing `<hostname>:<port>` (**MUST NOT** be combined with `name`)
-`timeout` | `float` | `1.0` | Timeout for commands, see [PhpRedis](https://github.com/phpredis/phpredis/blob/develop/cluster.markdown#timeouts) timeouts documentation for more background.
-`read_timeout` | `float` | `2.0` | Read timeout for commands, see [PhpRedis](https://github.com/phpredis/phpredis/blob/develop/cluster.markdown#timeouts) timeouts documentation for more background.
-`persistent` | `bool` | `false` | Flag to specify whether to create a persistent connection or not
-`version` | `string` | "" | The Redis server version. **MUST** be specified in a [Semantic Versioning 2.0.0](https://semver.org/#semantic-versioning-200) format. This information is used to determine some features/capabilities without opening a connection to the server.
+| Name                  | Data Type                 | Default Value | Description                                                                                                                                                                                                                                        |
+|-----------------------|---------------------------|---------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `lib_options`         | `array`                   | `[]`          | Associative array of Redis options where the array key is the options constant value (see `RedisCluster::OPT_*` [constants](https://github.com/JetBrains/phpstorm-stubs/blob/master/redis/RedisCluster.php) for details).                          |
+| `namespace_separator` | `string`                  | ":"           | A separator for the namespace and prefix.                                                                                                                                                                                                          |
+| `password`            | `string`                  | ""            | Password to authenticate with Redis server                                                                                                                                                                                                         |
+| `name`                | `string`                  | ""            | Name to determine configuration from [php.ini](https://github.com/phpredis/phpredis/blob/develop/cluster.markdown#loading-a-cluster-configuration-by-name) (**MUST NOT** be combined with `seeds`)                                                 |
+| `seeds`               | `array`                   | `[]`          | List of strings containing `<hostname>:<port>` (**MUST NOT** be combined with `name`)                                                                                                                                                              |
+| `timeout`             | `float`                   | `1.0`         | Timeout for commands, see [PhpRedis](https://github.com/phpredis/phpredis/blob/develop/cluster.markdown#timeouts) timeouts documentation for more background.                                                                                      |
+| `read_timeout`        | `float`                   | `2.0`         | Read timeout for commands, see [PhpRedis](https://github.com/phpredis/phpredis/blob/develop/cluster.markdown#timeouts) timeouts documentation for more background.                                                                                 |
+| `persistent`          | `bool`                    | `false`       | Flag to specify whether to create a persistent connection or not                                                                                                                                                                                   |
+| `version`             | `string`                  | ""            | The Redis server version. **MUST** be specified in a [Semantic Versioning 2.0.0](https://semver.org/#semantic-versioning-200) format. This information is used to determine some features/capabilities without opening a connection to the server. |
+| `ssl_context`         | `array\|SslContext\|null` | `null`        | Associative array with [SSL context](https://www.php.net/manual/en/context.ssl.php) options. Can be also an instance of `SslContext` (class available from within the `redis` adapter). Available since adapter version v2.8.0.                    |
 
 ## Memory Adapter
 


### PR DESCRIPTION
### Release Notes for [3.12.2](https://github.com/laminas/laminas-cache/milestone/55)

3.12.x bugfix release (patch)

### 3.12.2

- Total issues resolved: **1**
- Total pull requests resolved: **1**
- Total contributors: **1**

#### Documentation

 - [300: Documentation: Add `ssl&#95;context` option to `RedisCluster` documentation](https://github.com/laminas/laminas-cache/pull/300) thanks to @boesing
