### PR TITLE
Add missing template param for `StorageInterface`

### DIFF
--- a/src/Storage/Adapter/AbstractAdapter.php
+++ b/src/Storage/Adapter/AbstractAdapter.php
@@ -31,6 +31,7 @@ use function sprintf;
 
 /**
  * @template TOptions of AdapterOptions
+ * @template-implements StorageInterface<TOptions>
  */
 abstract class AbstractAdapter implements StorageInterface, PluginAwareInterface
 {

--- a/src/Storage/StorageInterface.php
+++ b/src/Storage/StorageInterface.php
@@ -3,18 +3,23 @@
 namespace Laminas\Cache\Storage;
 
 use Laminas\Cache\Exception\ExceptionInterface;
+use Laminas\Cache\Storage\Adapter\AdapterOptions;
 
 /**
- * NOTE: when providing integrish cache keys in iterables, internal array conversion might convert these to int, even
+ * NOTE: when providing integerish cache keys in iterables, internal array conversion might convert these to int, even
  *       tho they were non-empty-string beforehand. See https://3v4l.org/GsiBl for more details.
  *
  * @psalm-type CacheKeyInIterableType = non-empty-string|int
+ * @template TOptions of AdapterOptions
  */
 interface StorageInterface
 {
-    public function setOptions(iterable|Adapter\AdapterOptions $options): self;
+    public function setOptions(iterable|AdapterOptions $options): self;
 
-    public function getOptions(): Adapter\AdapterOptions;
+    /**
+     * @return TOptions
+     */
+    public function getOptions(): AdapterOptions;
 
     /* reading */
     /**

--- a/test/Psr/CacheItemPool/TestAsset/FlushableStorageAdapterInterface.php
+++ b/test/Psr/CacheItemPool/TestAsset/FlushableStorageAdapterInterface.php
@@ -4,9 +4,14 @@ declare(strict_types=1);
 
 namespace LaminasTest\Cache\Psr\CacheItemPool\TestAsset;
 
+use Laminas\Cache\Storage\Adapter\AdapterOptions;
 use Laminas\Cache\Storage\FlushableInterface;
 use Laminas\Cache\Storage\StorageInterface;
 
+/**
+ * @template TOptions of AdapterOptions
+ * @template-extends StorageInterface<TOptions>
+ */
 interface FlushableStorageAdapterInterface extends StorageInterface, FlushableInterface
 {
 }

--- a/test/Psr/TestAsset/FlushableNamespaceStorageInterface.php
+++ b/test/Psr/TestAsset/FlushableNamespaceStorageInterface.php
@@ -4,8 +4,13 @@ declare(strict_types=1);
 
 namespace LaminasTest\Cache\Psr\TestAsset;
 
+use Laminas\Cache\Storage\Adapter\AdapterOptions;
 use Laminas\Cache\Storage\ClearByNamespaceInterface;
 
+/**
+ * @template TOptions of AdapterOptions
+ * @template-extends FlushableStorageInterface<TOptions>
+ */
 interface FlushableNamespaceStorageInterface extends FlushableStorageInterface, ClearByNamespaceInterface
 {
 }

--- a/test/Psr/TestAsset/FlushableStorageInterface.php
+++ b/test/Psr/TestAsset/FlushableStorageInterface.php
@@ -4,10 +4,15 @@ declare(strict_types=1);
 
 namespace LaminasTest\Cache\Psr\TestAsset;
 
+use Laminas\Cache\Storage\Adapter\AdapterOptions;
 use Laminas\Cache\Storage\FlushableInterface;
 use Laminas\Cache\Storage\PluginAwareInterface;
 use Laminas\Cache\Storage\StorageInterface;
 
+/**
+ * @template TOptions of AdapterOptions
+ * @template-extends StorageInterface<TOptions>
+ */
 interface FlushableStorageInterface extends StorageInterface, FlushableInterface, PluginAwareInterface
 {
 }

--- a/test/Storage/Adapter/TestAsset/AdapterWithStorageAndEventsCapableInterface.php
+++ b/test/Storage/Adapter/TestAsset/AdapterWithStorageAndEventsCapableInterface.php
@@ -4,10 +4,15 @@ declare(strict_types=1);
 
 namespace LaminasTest\Cache\Storage\Adapter\TestAsset;
 
+use Laminas\Cache\Storage\Adapter\AdapterOptions;
 use Laminas\Cache\Storage\Plugin\PluginInterface;
 use Laminas\Cache\Storage\StorageInterface;
 use Laminas\EventManager\EventsCapableInterface;
 
+/**
+ * @template TOptions of AdapterOptions
+ * @template-extends StorageInterface<TOptions>
+ */
 interface AdapterWithStorageAndEventsCapableInterface extends StorageInterface, EventsCapableInterface
 {
     public function hasPlugin(PluginInterface $plugin): bool;


### PR DESCRIPTION
<!--
Fill in the relevant information below to help triage your issue.

Assuming the current release is 1.5.0, the next patch release is 1.5.1, the next minor is 1.6.0 and the next major is 2.0.0, The Current release branch will be `1.5.x`, the next minor branch will be `1.6.x`, and the next major branch will be `2.0.x`

Pick the target branch based on the following criteria:
  * Documentation improvement: Current release branch 1.5.x
  * Bugfix: Current release branch 1.5.x
  * QA improvement (additional tests, CS fixes, etc.) that does not change code
    behavior: Next minor 1.6.x
  * New feature, or refactor of existing code: Next minor 1.6.x
  * Backwards incompatible features and refactoring: Next major 2.0.x

You MUST provide a signoff in your commits for us to be able to accept your
patch; you can do this by providing either the --signoff or -s flag when using
"git commit". Please see the project contributing guide and
https://developercertificate.org for details.
-->

|    Q          |   A
|-------------- | ------
| Bugfix        | yes
| BC Break      | soft
| New Feature   | no

### Description

<!--

Tell us about why this change is necessary:
- Are you fixing a bug or providing a failing unit test to demonstrate a bug?
  - How do you reproduce it?
  - What did you expect to happen?
  - What actually happened?
  - TARGET THE CURRENT RELEASE BRANCH

- Are you adding documentation?
  - TARGET THE CURRENT RELEASE BRANCH

- Are you providing a QA improvement (additional tests, CS fixes, etc.) that
  does not change behavior?
  - Explain why the changes are necessary
  - TARGET THE NEXT MINOR BRANCH

- Are you fixing a BC Break?
  - How do you reproduce it?
  - What was the previous behavior?
  - What is the current behavior?
  - TARGET THE CURRENT RELEASE BRANCH

- Are you adding something the library currently does not support?
  - Why should it be added?
  - What will it enable?
  - How will the code be used?
  - TARGET THE NEXT MINOR BRANCH OR THE NEXT MAJOR IF BC WILL BE BROKEN

- Are you refactoring code?
  - Why do you feel the refactor is necessary?
  - What types of refactoring are you doing?
  - TARGET THE NEXT MINOR BRANCH OR THE NEXT MAJOR IF BC WILL BE BROKEN
-->

Since all laminas cache adapters are extending `AbstractStorage`, there was already a template `TOptions` available in that abstract class. Sadly, I forgot to add that to the `StorageInterface` which is problematic when it comes to interface usage.

This patch adds options template as a bugfix since we do not change any code (besides providing the options generic).
