### PR TITLE
Add adapter options template to `StorageInterface` usage

### DIFF
--- a/src/Pattern/AbstractStorageCapablePattern.php
+++ b/src/Pattern/AbstractStorageCapablePattern.php
@@ -4,15 +4,22 @@ declare(strict_types=1);
 
 namespace Laminas\Cache\Pattern;
 
+use Laminas\Cache\Storage\Adapter\AdapterOptions;
 use Laminas\Cache\Storage\StorageInterface;
 
 abstract class AbstractStorageCapablePattern extends AbstractPattern implements StorageCapableInterface
 {
+    /**
+     * @param StorageInterface<AdapterOptions> $storage
+     */
     public function __construct(protected StorageInterface $storage, ?PatternOptions $options = null)
     {
         parent::__construct($options);
     }
 
+    /**
+     * @return StorageInterface<AdapterOptions>
+     */
     public function getStorage(): StorageInterface
     {
         return $this->storage;

--- a/src/Pattern/ObjectCache.php
+++ b/src/Pattern/ObjectCache.php
@@ -3,6 +3,7 @@
 namespace Laminas\Cache\Pattern;
 
 use Laminas\Cache\Exception;
+use Laminas\Cache\Storage\Adapter\AdapterOptions;
 use Laminas\Cache\Storage\StorageInterface;
 use Stringable;
 use Throwable;
@@ -21,6 +22,9 @@ final class ObjectCache extends AbstractStorageCapablePattern implements Stringa
 {
     private CallbackCache $callbackCache;
 
+    /**
+     * @param StorageInterface<AdapterOptions> $storage
+     */
     public function __construct(StorageInterface $storage, ?PatternOptions $options = null)
     {
         parent::__construct($storage, $options);

--- a/src/Psr/CacheItemPool/CacheItemPoolDecorator.php
+++ b/src/Psr/CacheItemPool/CacheItemPoolDecorator.php
@@ -7,6 +7,7 @@ use Laminas\Cache\Exception;
 use Laminas\Cache\Psr\Clock;
 use Laminas\Cache\Psr\MaximumKeyLengthTrait;
 use Laminas\Cache\Psr\SerializationTrait;
+use Laminas\Cache\Storage\Adapter\AdapterOptions;
 use Laminas\Cache\Storage\ClearByNamespaceInterface;
 use Laminas\Cache\Storage\FlushableInterface;
 use Laminas\Cache\Storage\StorageInterface;
@@ -292,6 +293,7 @@ final class CacheItemPoolDecorator implements CacheItemPoolInterface
     /**
      * Throws exception is storage is not compatible with PSR-6
      *
+     * @param StorageInterface<AdapterOptions> $storage
      * @throws CacheException
      */
     private function validateStorage(StorageInterface $storage): void

--- a/src/Psr/MaximumKeyLengthTrait.php
+++ b/src/Psr/MaximumKeyLengthTrait.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Laminas\Cache\Psr;
 
 use Laminas\Cache\Psr\SimpleCache\SimpleCacheInvalidArgumentException;
+use Laminas\Cache\Storage\Adapter\AdapterOptions;
 use Laminas\Cache\Storage\Capabilities;
 use Laminas\Cache\Storage\StorageInterface;
 
@@ -32,6 +33,9 @@ trait MaximumKeyLengthTrait
     /** @var int<0,max> */
     private int $maximumKeyLength;
 
+    /**
+     * @param StorageInterface<AdapterOptions> $storage
+     */
     private function memoizeMaximumKeyLengthCapability(StorageInterface $storage, Capabilities $capabilities): void
     {
         $maximumKeyLength = $capabilities->maxKeyLength;

--- a/src/Psr/SerializationTrait.php
+++ b/src/Psr/SerializationTrait.php
@@ -2,6 +2,7 @@
 
 namespace Laminas\Cache\Psr;
 
+use Laminas\Cache\Storage\Adapter\AdapterOptions;
 use Laminas\Cache\Storage\StorageInterface;
 
 use function in_array;
@@ -16,6 +17,8 @@ trait SerializationTrait
 {
     /**
      * Determine if the given storage adapter requires serialization.
+     *
+     * @param StorageInterface<AdapterOptions> $storage
      */
     private function isSerializationRequired(StorageInterface $storage): bool
     {

--- a/src/Psr/SimpleCache/SimpleCacheDecorator.php
+++ b/src/Psr/SimpleCache/SimpleCacheDecorator.php
@@ -8,6 +8,7 @@ use Laminas\Cache\Exception\InvalidArgumentException as LaminasCacheInvalidArgum
 use Laminas\Cache\Psr\Clock;
 use Laminas\Cache\Psr\MaximumKeyLengthTrait;
 use Laminas\Cache\Psr\SerializationTrait;
+use Laminas\Cache\Storage\Adapter\AdapterOptions;
 use Laminas\Cache\Storage\Capabilities;
 use Laminas\Cache\Storage\ClearByNamespaceInterface;
 use Laminas\Cache\Storage\FlushableInterface;
@@ -54,6 +55,9 @@ final class SimpleCacheDecorator implements SimpleCacheInterface
 
     private ClockInterface $clock;
 
+    /**
+     * @param StorageInterface<AdapterOptions> $storage
+     */
     public function __construct(
         private readonly StorageInterface $storage,
         ?ClockInterface $clock = null,

--- a/src/Storage/Adapter/AdapterOptions.php
+++ b/src/Storage/Adapter/AdapterOptions.php
@@ -46,6 +46,8 @@ class AdapterOptions extends AbstractOptions
 
     /**
      * The adapter using these options
+     *
+     * @var StorageInterface<AdapterOptions>
      */
     protected ?StorageInterface $adapter = null;
 
@@ -78,6 +80,8 @@ class AdapterOptions extends AbstractOptions
 
     /**
      * Adapter using this instance
+     *
+     * @param StorageInterface<AdapterOptions> $adapter
      */
     public function setAdapter(?StorageInterface $adapter = null): self
     {

--- a/src/Storage/Adapter/KeyListIterator.php
+++ b/src/Storage/Adapter/KeyListIterator.php
@@ -32,6 +32,7 @@ final class KeyListIterator implements IteratorInterface, Countable
     protected int $position = 0;
 
     /**
+     * @param StorageInterface<AdapterOptions> $storage
      * @param array<int,non-empty-string> $keys Keys to iterate over
      */
     public function __construct(
@@ -42,7 +43,7 @@ final class KeyListIterator implements IteratorInterface, Countable
     }
 
     /**
-     * Get storage instance
+     * @return StorageInterface<AdapterOptions>
      */
     public function getStorage(): StorageInterface
     {

--- a/src/Storage/Event.php
+++ b/src/Storage/Event.php
@@ -3,6 +3,7 @@
 namespace Laminas\Cache\Storage;
 
 use ArrayObject;
+use Laminas\Cache\Storage\Adapter\AdapterOptions;
 use Laminas\EventManager\Event as BaseEvent;
 
 /** @extends BaseEvent<StorageInterface, ArrayObject> */
@@ -12,6 +13,7 @@ class Event extends BaseEvent
      * Accept a storage adapter and its parameters.
      *
      * @param non-empty-string $name Event name
+     * @param StorageInterface<AdapterOptions> $storage
      * @param ArrayObject<string,mixed> $params
      */
     public function __construct(string $name, StorageInterface $storage, ArrayObject $params)
@@ -24,7 +26,7 @@ class Event extends BaseEvent
      *
      * @see    \Laminas\EventManager\Event::setTarget()
      *
-     * @param StorageInterface $target
+     * @param StorageInterface<AdapterOptions> $target
      */
     public function setTarget($target): void
     {
@@ -36,6 +38,8 @@ class Event extends BaseEvent
      * Alias of setTarget
      *
      * @see    \Laminas\EventManager\Event::setTarget()
+     *
+     * @param StorageInterface<AdapterOptions> $storage
      */
     public function setStorage(StorageInterface $storage): self
     {
@@ -45,6 +49,8 @@ class Event extends BaseEvent
 
     /**
      * Alias of getTarget
+     *
+     * @return StorageInterface<AdapterOptions>
      */
     public function getStorage(): StorageInterface
     {

--- a/src/Storage/ExceptionEvent.php
+++ b/src/Storage/ExceptionEvent.php
@@ -3,6 +3,7 @@
 namespace Laminas\Cache\Storage;
 
 use ArrayObject;
+use Laminas\Cache\Storage\Adapter\AdapterOptions;
 use Throwable;
 
 class ExceptionEvent extends PostEvent
@@ -21,6 +22,7 @@ class ExceptionEvent extends PostEvent
      * Accept a target and its parameters.
      *
      * @param non-empty-string $name Event name
+     * @param StorageInterface<AdapterOptions> $storage
      * @param ArrayObject<string,mixed> $params
      */
     public function __construct(

--- a/src/Storage/Plugin/IgnoreUserAbort.php
+++ b/src/Storage/Plugin/IgnoreUserAbort.php
@@ -2,6 +2,7 @@
 
 namespace Laminas\Cache\Storage\Plugin;
 
+use Laminas\Cache\Storage\Adapter\AdapterOptions;
 use Laminas\Cache\Storage\Event;
 use Laminas\Cache\Storage\StorageInterface;
 use Laminas\EventManager\EventManagerInterface;
@@ -13,6 +14,8 @@ final class IgnoreUserAbort extends AbstractPlugin
 {
     /**
      * The storage who activated ignore_user_abort.
+     *
+     * @var StorageInterface<AdapterOptions>
      */
     protected ?StorageInterface $activatedTarget = null;
 

--- a/src/Storage/PostEvent.php
+++ b/src/Storage/PostEvent.php
@@ -3,6 +3,7 @@
 namespace Laminas\Cache\Storage;
 
 use ArrayObject;
+use Laminas\Cache\Storage\Adapter\AdapterOptions;
 
 class PostEvent extends Event
 {
@@ -15,6 +16,7 @@ class PostEvent extends Event
      * Accept a target and its parameters.
      *
      * @param non-empty-string $name Event name
+     * @param StorageInterface<AdapterOptions> $storage
      * @param ArrayObject<string,mixed> $params
      */
     public function __construct(string $name, StorageInterface $storage, ArrayObject $params, mixed $result)


### PR DESCRIPTION
<!--
Fill in the relevant information below to help triage your issue.

Assuming the current release is 1.5.0, the next patch release is 1.5.1, the next minor is 1.6.0 and the next major is 2.0.0, The Current release branch will be `1.5.x`, the next minor branch will be `1.6.x`, and the next major branch will be `2.0.x`

Pick the target branch based on the following criteria:
  * Documentation improvement: Current release branch 1.5.x
  * Bugfix: Current release branch 1.5.x
  * QA improvement (additional tests, CS fixes, etc.) that does not change code
    behavior: Next minor 1.6.x
  * New feature, or refactor of existing code: Next minor 1.6.x
  * Backwards incompatible features and refactoring: Next major 2.0.x

You MUST provide a signoff in your commits for us to be able to accept your
patch; you can do this by providing either the --signoff or -s flag when using
"git commit". Please see the project contributing guide and
https://developercertificate.org for details.
-->

|    Q          |   A
|-------------- | ------
| Bugfix        | yes
| BC Break      | soft

### Description

<!--

Tell us about why this change is necessary:
- Are you fixing a bug or providing a failing unit test to demonstrate a bug?
  - How do you reproduce it?
  - What did you expect to happen?
  - What actually happened?
  - TARGET THE CURRENT RELEASE BRANCH

- Are you adding documentation?
  - TARGET THE CURRENT RELEASE BRANCH

- Are you providing a QA improvement (additional tests, CS fixes, etc.) that
  does not change behavior?
  - Explain why the changes are necessary
  - TARGET THE NEXT MINOR BRANCH

- Are you fixing a BC Break?
  - How do you reproduce it?
  - What was the previous behavior?
  - What is the current behavior?
  - TARGET THE CURRENT RELEASE BRANCH

- Are you adding something the library currently does not support?
  - Why should it be added?
  - What will it enable?
  - How will the code be used?
  - TARGET THE NEXT MINOR BRANCH OR THE NEXT MAJOR IF BC WILL BE BROKEN

- Are you refactoring code?
  - Why do you feel the refactor is necessary?
  - What types of refactoring are you doing?
  - TARGET THE NEXT MINOR BRANCH OR THE NEXT MAJOR IF BC WILL BE BROKEN
-->

With adding `AdapterOptions` template to `StorageInterface` in v4.0.1, some usages of `StorageInterface` were not adapted. This adds adapter options generics to the usages of `StorageInterface`. Since the usages do not require any specific options, using `AdapterOptions` should be fine as all adapter options of the adapters are extending `AdapterOptions` anyways.