### PR TITLE
Add new `max_items` `Memory` adapter option

### DIFF
--- a/docs/book/v4/storage/adapter.md
+++ b/docs/book/v4/storage/adapter.md
@@ -733,7 +733,7 @@ This adapter implements the following interfaces:
 >
 > The adapter has the following behavior in regard to the `max_items` option:
 >
-> - If the items persisted to the memory cache are exceeding the limit, a new item will be stored while an older item will be removed
+> - If the items persisted to the memory cache are exceeding the limit, a new item will be stored while the oldest item will be removed
 
 > ### Current process only
 >

--- a/docs/book/v4/storage/adapter.md
+++ b/docs/book/v4/storage/adapter.md
@@ -712,9 +712,9 @@ This adapter implements the following interfaces:
 |----------------------|---------------------------------------------------------------------------------|
 | `supportedDatatypes` | `string`, `null`, `boolean`, `integer`, `double`, `array`, `object`, `resource` |
 | `ttlSupported`       | `true`                                                                          |
-| `ttlPrecision`       | `0.05`                                                                          |
+| `ttlPrecision`       | `1`                                                                             |
 | `usesRequestTime`    | `false`                                                                         |
-| `maxKeyLength`       | `0`                                                                             |
+| `maxKeyLength`       | `0` (unlimited)                                                                 |
 | `namespaceIsPrefix`  | `false`                                                                         |
 
 ### Metadata
@@ -725,19 +725,15 @@ This adapter implements the following interfaces:
 
 ### Adapter Specific Options
 
-| Name           | Data Type     | Default Value                   | Description                                                     |
-|----------------|---------------|---------------------------------|-----------------------------------------------------------------|
-| `memory_limit` | `string\|int` | 50% of `memory_limit` INI value | Limit of how much memory can PHP allocate to allow store items. |
+| Name        | Data Type | Default Value   | Description                                                                                         |
+|-------------|-----------|-----------------|-----------------------------------------------------------------------------------------------------|
+| `max_items` | `int`     | `0` (unlimited) | Limit of how many cache items are allowed to be stored. Available with v3.0 of the `Memory` adapter |
 
-> #### Memory Limit
+> #### Max Items
 >
-> The adapter has the following behavior with regards to the memory limit:
+> The adapter has the following behavior in regard to the `max_items` option:
 >
-> - If the consumed memory exceeds the limit provided, an `OutOfSpaceException`
-    >   is thrown.
-> - A number less the or equal to zero disables the memory limit.
-> - When a value is provided for the memory limit, the value is measured in
-    >   bytes. Shorthand notation may also be provided.
+> - If the items persisted to the memory cache are exceeding the limit, a new item will be stored while an older item will be removed
 
 > ### Current process only
 >


### PR DESCRIPTION
<!--
Fill in the relevant information below to help triage your issue.

Assuming the current release is 1.5.0, the next patch release is 1.5.1, the next minor is 1.6.0 and the next major is 2.0.0, The Current release branch will be `1.5.x`, the next minor branch will be `1.6.x`, and the next major branch will be `2.0.x`

Pick the target branch based on the following criteria:
  * Documentation improvement: Current release branch 1.5.x
  * Bugfix: Current release branch 1.5.x
  * QA improvement (additional tests, CS fixes, etc.) that does not change code
    behavior: Next minor 1.6.x
  * New feature, or refactor of existing code: Next minor 1.6.x
  * Backwards incompatible features and refactoring: Next major 2.0.x

You MUST provide a signoff in your commits for us to be able to accept your
patch; you can do this by providing either the --signoff or -s flag when using
"git commit". Please see the project contributing guide and
https://developercertificate.org for details.
-->

|    Q          |   A
|-------------- | ------
| Documentation | yes

### Description

<!--

Tell us about why this change is necessary:
- Are you fixing a bug or providing a failing unit test to demonstrate a bug?
  - How do you reproduce it?
  - What did you expect to happen?
  - What actually happened?
  - TARGET THE CURRENT RELEASE BRANCH

- Are you adding documentation?
  - TARGET THE CURRENT RELEASE BRANCH

- Are you providing a QA improvement (additional tests, CS fixes, etc.) that
  does not change behavior?
  - Explain why the changes are necessary
  - TARGET THE NEXT MINOR BRANCH

- Are you fixing a BC Break?
  - How do you reproduce it?
  - What was the previous behavior?
  - What is the current behavior?
  - TARGET THE CURRENT RELEASE BRANCH

- Are you adding something the library currently does not support?
  - Why should it be added?
  - What will it enable?
  - How will the code be used?
  - TARGET THE NEXT MINOR BRANCH OR THE NEXT MAJOR IF BC WILL BE BROKEN

- Are you refactoring code?
  - Why do you feel the refactor is necessary?
  - What types of refactoring are you doing?
  - TARGET THE NEXT MINOR BRANCH OR THE NEXT MAJOR IF BC WILL BE BROKEN
-->

With v3.0 of the `Memory` adapter, we introduced `max_items` option and dropped `memory_limit` option.