### PR TITLE
Update PSR-6 unsupported adapters list in documentation

### DIFF
--- a/docs/book/v4/psr6.md
+++ b/docs/book/v4/psr6.md
@@ -49,7 +49,7 @@ found.
 ## Supported Adapters
 
 The PSR-6 specification requires that the underlying storage support time-to-live (TTL), which is set when the
-item is saved. For this reason the following adapters cannot be used: `Dba`, `Memory` and `Session`. The
+item is saved. For this reason the following adapters **cannot** be used: `Dba`, `Memory` and `Session`. The
 `XCache` adapter calculates TTLs based on the request time, not the time the item is actually persisted, which means
 that it also cannot be used.
 

--- a/docs/book/v4/psr6.md
+++ b/docs/book/v4/psr6.md
@@ -49,7 +49,7 @@ found.
 ## Supported Adapters
 
 The PSR-6 specification requires that the underlying storage support time-to-live (TTL), which is set when the
-item is saved. For this reason the following adapters cannot be used: `Dba`, `Filesystem`, `Memory` and `Session`. The
+item is saved. For this reason the following adapters cannot be used: `Dba`, `Memory` and `Session`. The
 `XCache` adapter calculates TTLs based on the request time, not the time the item is actually persisted, which means
 that it also cannot be used.
 


### PR DESCRIPTION
Removed `Filesystem` from the list of unsupported adapters as it is no longer relevant.

Reference:

- https://github.com/laminas/laminas-cache-storage-adapter-filesystem/releases/tag/3.0.0
- https://github.com/laminas/laminas-cache-storage-adapter-filesystem/pull/91