### PR TITLE
Fix proposal 355

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -394,6 +394,9 @@
     <PossiblyUnusedProperty>
       <code><![CDATA[$property]]></code>
     </PossiblyUnusedProperty>
+    <UnusedProperty>
+      <code><![CDATA[$closure]]></code>
+    </UnusedProperty>
   </file>
   <file src="test/Psr/CacheItemPool/CacheItemPoolDecoratorTest.php">
     <InvalidArgument>

--- a/src/Pattern/CallbackCache.php
+++ b/src/Pattern/CallbackCache.php
@@ -7,6 +7,7 @@ use Throwable;
 
 use function array_key_exists;
 use function array_values;
+use function is_array;
 use function is_callable;
 use function is_object;
 use function md5;
@@ -111,17 +112,16 @@ final class CallbackCache extends AbstractStorageCapablePattern
      */
     protected function generateCallbackKey(callable $callback, array $args): string
     {
+        if (! is_callable($callback, false, $callbackKey)) {
+            throw new Exception\InvalidArgumentException('Invalid callback');
+        }
 
         // Create a cache key for the ObjectCache use case.
         $options = $this->getOptions();
-        if (is_object($options->getObject())) {
+        if (is_object($options->getObject()) && is_array($callback) && isset($callback[1])) {
             $callbackKey = md5($options->getObjectKey() . '::' . strtolower($callback[1]));
             $argumentKey = $this->generateArgumentsKey($args);
             return $callbackKey . $argumentKey;
-        }
-
-        if (! is_callable($callback, false, $callbackKey)) {
-            throw new Exception\InvalidArgumentException('Invalid callback');
         }
 
         // functions, methods and classnames are case-insensitive

--- a/src/Pattern/CallbackCache.php
+++ b/src/Pattern/CallbackCache.php
@@ -111,6 +111,15 @@ final class CallbackCache extends AbstractStorageCapablePattern
      */
     protected function generateCallbackKey(callable $callback, array $args): string
     {
+
+        // Create a cache key for the ObjectCache use case.
+        $options = $this->getOptions();
+        if (is_object($options->getObject())) {
+            $callbackKey = md5($options->getObjectKey() . '::' . strtolower($callback[1]));
+            $argumentKey = $this->generateArgumentsKey($args);
+            return $callbackKey . $argumentKey;
+        }
+
         if (! is_callable($callback, false, $callbackKey)) {
             throw new Exception\InvalidArgumentException('Invalid callback');
         }

--- a/test/Pattern/TestAsset/TestObjectCache.php
+++ b/test/Pattern/TestAsset/TestObjectCache.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace LaminasTest\Cache\Pattern\TestAsset;
 
+use Closure;
+
 use function func_get_args;
 use function implode;
 
@@ -22,13 +24,15 @@ final class TestObjectCache
     /** @var string */
     public $property = 'testProperty';
 
-    private \Closure $closure;
+    private Closure $closure;
 
     public function __construct()
     {
         // Closures prevent serialization - this acts as a detector to verify this object is not serialized during test.
-        $this->closure = function () {};
+        $this->closure = function (): void {
+        };
     }
+
     public function bar(): string
     {
         ++static::$fooCounter;

--- a/test/Pattern/TestAsset/TestObjectCache.php
+++ b/test/Pattern/TestAsset/TestObjectCache.php
@@ -22,6 +22,13 @@ final class TestObjectCache
     /** @var string */
     public $property = 'testProperty';
 
+    private \Closure $closure;
+
+    public function __construct()
+    {
+        // Closures prevent serialization - this acts as a detector to verify this object is not serialized during test.
+        $this->closure = function () {};
+    }
     public function bar(): string
     {
         ++static::$fooCounter;


### PR DESCRIPTION
<!--
Fill in the relevant information below to help triage your issue.

Assuming the current release is 1.5.0, the next patch release is 1.5.1, the next minor is 1.6.0 and the next major is 2.0.0, The Current release branch will be `1.5.x`, the next minor branch will be `1.6.x`, and the next major branch will be `2.0.x`

Pick the target branch based on the following criteria:
  * Documentation improvement: Current release branch 1.5.x
  * Bugfix: Current release branch 1.5.x
  * QA improvement (additional tests, CS fixes, etc.) that does not change code
    behavior: Next minor 1.6.x
  * New feature, or refactor of existing code: Next minor 1.6.x
  * Backwards incompatible features and refactoring: Next major 2.0.x

You MUST provide a signoff in your commits for us to be able to accept your
patch; you can do this by providing either the --signoff or -s flag when using
"git commit". Please see the project contributing guide and
https://developercertificate.org for details.
-->

|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description

I discovered that `\Laminas\Cache\Pattern\ObjectCache`, after being untangled and not inheriting from `CallbackCache` anymore, has changed the way the cache key computation is done and now is sensitive to all properties being present, and cannot deal with Closures present in them.

This is described in issue #355.

Expected behaviour (identical with V3.x):
- `ObjectCache` allows to cache object trees that contain Closures, as they are not used to create a cache key.
- `ObjectCache` is consistently creating the same cache key independent from any property values that are contained in the object tree.

Observed behavior with V4.0 up to v4.1.0:
- `ObjectCache` throws an exception when encountering a Closure in a property.
- `ObjectCache` creates differing cache keys if properties change inside the object tree.

This proposal adds a test case indicator by simply forcing a useless Closure into the `\LaminasTest\Cache\Pattern\TestAsset\TestObjectCache`, which prevents serializing this object.

Then a code path is added to `CallbackCache` that detects if an object is present in the `PatternOptions`, which is taken as an indicator we are dealing with `ObjectCache` forwarding the call into `CallbackCache`, and apply the previously existing cache key logic that was present in `ObjectCache::generateCallbackKey()` from version 3.x. This will restore the previous behavior.

This PR targets the 4.2.x branch, as there is currently only a minor lock file commit after the 4.1.x branch, and merging this fix may be considered serious enough to warrant a new minor release, as it reverts a major version change I consider to be accidental.

<!--

Tell us about why this change is necessary:
- Are you fixing a bug or providing a failing unit test to demonstrate a bug?
  - How do you reproduce it?
  - What did you expect to happen?
  - What actually happened?
  - TARGET THE CURRENT RELEASE BRANCH

- Are you adding documentation?
  - TARGET THE CURRENT RELEASE BRANCH

- Are you providing a QA improvement (additional tests, CS fixes, etc.) that
  does not change behavior?
  - Explain why the changes are necessary
  - TARGET THE NEXT MINOR BRANCH

- Are you fixing a BC Break?
  - How do you reproduce it?
  - What was the previous behavior?
  - What is the current behavior?
  - TARGET THE CURRENT RELEASE BRANCH

- Are you adding something the library currently does not support?
  - Why should it be added?
  - What will it enable?
  - How will the code be used?
  - TARGET THE NEXT MINOR BRANCH OR THE NEXT MAJOR IF BC WILL BE BROKEN

- Are you refactoring code?
  - Why do you feel the refactor is necessary?
  - What types of refactoring are you doing?
  - TARGET THE NEXT MINOR BRANCH OR THE NEXT MAJOR IF BC WILL BE BROKEN
-->
