### PR TITLE
Allow PHP 8.5, remove PHP 8.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "process-timeout": 600,
         "sort-packages": true,
         "platform": {
-            "php": "8.1.99"
+            "php": "8.2.99"
         },
         "allow-plugins": {
             "dealerdirect/phpcodesniffer-composer-installer": true
@@ -34,9 +34,9 @@
         }
     },
     "require": {
-        "php": "~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0",
+        "php": "~8.2.0 || ~8.3.0 || ~8.4.0 || ~8.5.0",
         "laminas/laminas-eventmanager": "^3.4",
-        "laminas/laminas-servicemanager": "^4.1",
+        "laminas/laminas-servicemanager": "^4.5",
         "laminas/laminas-stdlib": "^3.20",
         "psr/cache": "^2.0 || ^3.0",
         "psr/clock": "^1.0",
@@ -47,10 +47,10 @@
         "laminas/laminas-cli": "^1.11",
         "laminas/laminas-coding-standard": "~3.1.0",
         "laminas/laminas-config-aggregator": "^1.17",
-        "laminas/laminas-serializer": "^3.1",
-        "phpunit/phpunit": "^10.5.38",
+        "laminas/laminas-serializer": "^3.2",
+        "phpunit/phpunit": "^11.5.37",
         "psalm/plugin-phpunit": "^0.19.0",
-        "vimeo/psalm": "^5.26.1"
+        "vimeo/psalm": "^6"
     },
     "conflict": {
         "laminas/laminas-serializer": "<3.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,30 +4,30 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "8d3a7ccba8f4515a1be42e78b5bd2256",
+    "content-hash": "f9a5f56713dd66ff7aeb8fb88869d25a",
     "packages": [
         {
             "name": "brick/varexporter",
-            "version": "0.4.0",
+            "version": "0.6.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/brick/varexporter.git",
-                "reference": "2fd038f7c9d12d468130c6e1b3ce06e4160a7dbb"
+                "reference": "af98bfc2b702a312abbcaff37656dbe419cec5bc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/brick/varexporter/zipball/2fd038f7c9d12d468130c6e1b3ce06e4160a7dbb",
-                "reference": "2fd038f7c9d12d468130c6e1b3ce06e4160a7dbb",
+                "url": "https://api.github.com/repos/brick/varexporter/zipball/af98bfc2b702a312abbcaff37656dbe419cec5bc",
+                "reference": "af98bfc2b702a312abbcaff37656dbe419cec5bc",
                 "shasum": ""
             },
             "require": {
-                "nikic/php-parser": "^4.0",
-                "php": "^7.4 || ^8.0"
+                "nikic/php-parser": "^5.0",
+                "php": "^8.1"
             },
             "require-dev": {
                 "php-coveralls/php-coveralls": "^2.2",
-                "phpunit/phpunit": "^8.5 || ^9.0",
-                "vimeo/psalm": "5.15.0"
+                "phpunit/phpunit": "^10.5",
+                "vimeo/psalm": "6.8.4"
             },
             "type": "library",
             "autoload": {
@@ -45,7 +45,7 @@
             ],
             "support": {
                 "issues": "https://github.com/brick/varexporter/issues",
-                "source": "https://github.com/brick/varexporter/tree/0.4.0"
+                "source": "https://github.com/brick/varexporter/tree/0.6.0"
             },
             "funding": [
                 {
@@ -53,37 +53,40 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-09-01T21:10:07+00:00"
+            "time": "2025-02-20T17:42:39+00:00"
         },
         {
             "name": "laminas/laminas-eventmanager",
-            "version": "3.14.0",
+            "version": "3.15.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-eventmanager.git",
-                "reference": "1837cafaaaee74437f6d8ec9ff7da03e6f81d809"
+                "reference": "90b4bd33264629af8e39caf5aa83473ac03aa04c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-eventmanager/zipball/1837cafaaaee74437f6d8ec9ff7da03e6f81d809",
-                "reference": "1837cafaaaee74437f6d8ec9ff7da03e6f81d809",
+                "url": "https://api.github.com/repos/laminas/laminas-eventmanager/zipball/90b4bd33264629af8e39caf5aa83473ac03aa04c",
+                "reference": "90b4bd33264629af8e39caf5aa83473ac03aa04c",
                 "shasum": ""
             },
             "require": {
-                "php": "~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0"
+                "php": "~8.2.0 || ~8.3.0 || ~8.4.0 || ~8.5.0"
             },
             "conflict": {
                 "container-interop/container-interop": "<1.2",
                 "zendframework/zend-eventmanager": "*"
             },
             "require-dev": {
-                "laminas/laminas-coding-standard": "~3.0.0",
+                "amphp/dns": "^2.2",
+                "amphp/socket": "^2.3.1",
+                "laminas/laminas-coding-standard": "~3.1.0",
                 "laminas/laminas-stdlib": "^3.20",
                 "phpbench/phpbench": "^1.3.1",
-                "phpunit/phpunit": "^10.5.38",
+                "phpunit/phpunit": "^10.5.58",
                 "psalm/plugin-phpunit": "^0.19.0",
                 "psr/container": "^1.1.2 || ^2.0.2",
-                "vimeo/psalm": "^5.26.1"
+                "sebastian/recursion-context": "^5.0.1",
+                "vimeo/psalm": "^6.13"
             },
             "suggest": {
                 "laminas/laminas-stdlib": "^2.7.3 || ^3.0, to use the FilterChain feature",
@@ -121,26 +124,26 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2024-11-21T11:31:22+00:00"
+            "time": "2025-10-31T10:29:01+00:00"
         },
         {
             "name": "laminas/laminas-servicemanager",
-            "version": "4.4.0",
+            "version": "4.5.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-servicemanager.git",
-                "reference": "74da44d07e493b834347123242d0047976fb9932"
+                "reference": "a6996829c8ce55025cca1b57b1e8a8b165e3926c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-servicemanager/zipball/74da44d07e493b834347123242d0047976fb9932",
-                "reference": "74da44d07e493b834347123242d0047976fb9932",
+                "url": "https://api.github.com/repos/laminas/laminas-servicemanager/zipball/a6996829c8ce55025cca1b57b1e8a8b165e3926c",
+                "reference": "a6996829c8ce55025cca1b57b1e8a8b165e3926c",
                 "shasum": ""
             },
             "require": {
-                "brick/varexporter": "^0.3.8 || ^0.4.0 || ^0.5.0",
+                "brick/varexporter": "^0.3.8 || ^0.4.0 || ^0.5.0 || ^0.6.0",
                 "laminas/laminas-stdlib": "^3.19",
-                "php": "~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0",
+                "php": "~8.2.0 || ~8.3.0 || ~8.4.0 || ~8.5.0",
                 "psr/container": "^1.1 || ^2.0"
             },
             "conflict": {
@@ -154,14 +157,14 @@
                 "composer/package-versions-deprecated": "^1.11.99.5",
                 "friendsofphp/proxy-manager-lts": "^1.0.18",
                 "laminas/laminas-cli": "^1.11",
-                "laminas/laminas-coding-standard": "~3.0.1",
-                "laminas/laminas-container-config-test": "^1.0",
+                "laminas/laminas-coding-standard": "~3.1.0",
+                "laminas/laminas-container-config-test": "^1.1",
                 "mikey179/vfsstream": "^1.6.12",
-                "phpbench/phpbench": "^1.4.0",
-                "phpunit/phpunit": "^10.5.44",
-                "psalm/plugin-phpunit": "^0.19.2",
-                "symfony/console": "^6.4.17 || ^7.0",
-                "vimeo/psalm": "^6.2.0"
+                "phpbench/phpbench": "^1.4.1",
+                "phpunit/phpunit": "^10.5.58",
+                "psalm/plugin-phpunit": "^0.19.5",
+                "symfony/console": "^6.4.17 || ^7.3.4",
+                "vimeo/psalm": "^6.13.1"
             },
             "suggest": {
                 "friendsofphp/proxy-manager-lts": "To handle lazy initialization of services",
@@ -198,7 +201,7 @@
                 "chat": "https://laminas.dev/chat",
                 "forum": "https://discourse.laminas.dev",
                 "issues": "https://github.com/laminas/laminas-servicemanager/issues",
-                "source": "https://github.com/laminas/laminas-servicemanager/tree/4.4.0"
+                "source": "https://github.com/laminas/laminas-servicemanager/tree/4.5.0"
             },
             "funding": [
                 {
@@ -206,34 +209,34 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2025-02-04T06:13:50+00:00"
+            "time": "2025-10-14T09:41:04+00:00"
         },
         {
             "name": "laminas/laminas-stdlib",
-            "version": "3.20.0",
+            "version": "3.21.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-stdlib.git",
-                "reference": "8974a1213be42c3e2f70b2c27b17f910291ab2f4"
+                "reference": "b1c81514cfe158aadf724c42b34d3d0a8164c096"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-stdlib/zipball/8974a1213be42c3e2f70b2c27b17f910291ab2f4",
-                "reference": "8974a1213be42c3e2f70b2c27b17f910291ab2f4",
+                "url": "https://api.github.com/repos/laminas/laminas-stdlib/zipball/b1c81514cfe158aadf724c42b34d3d0a8164c096",
+                "reference": "b1c81514cfe158aadf724c42b34d3d0a8164c096",
                 "shasum": ""
             },
             "require": {
-                "php": "~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0"
+                "php": "~8.2.0 || ~8.3.0 || ~8.4.0 || ~8.5.0"
             },
             "conflict": {
                 "zendframework/zend-stdlib": "*"
             },
             "require-dev": {
-                "laminas/laminas-coding-standard": "^3.0",
-                "phpbench/phpbench": "^1.3.1",
-                "phpunit/phpunit": "^10.5.38",
-                "psalm/plugin-phpunit": "^0.19.0",
-                "vimeo/psalm": "^5.26.1"
+                "laminas/laminas-coding-standard": "^3.1.0",
+                "phpbench/phpbench": "^1.4.1",
+                "phpunit/phpunit": "^11.5.42",
+                "psalm/plugin-phpunit": "^0.19.5",
+                "vimeo/psalm": "^6.13.1"
             },
             "type": "library",
             "autoload": {
@@ -265,29 +268,31 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2024-10-29T13:46:07+00:00"
+            "time": "2025-10-11T18:13:12+00:00"
         },
         {
             "name": "nikic/php-parser",
-            "version": "v4.19.4",
+            "version": "v5.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "715f4d25e225bc47b293a8b997fe6ce99bf987d2"
+                "reference": "dca41cd15c2ac9d055ad70dbfd011130757d1f82"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/715f4d25e225bc47b293a8b997fe6ce99bf987d2",
-                "reference": "715f4d25e225bc47b293a8b997fe6ce99bf987d2",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/dca41cd15c2ac9d055ad70dbfd011130757d1f82",
+                "reference": "dca41cd15c2ac9d055ad70dbfd011130757d1f82",
                 "shasum": ""
             },
             "require": {
+                "ext-ctype": "*",
+                "ext-json": "*",
                 "ext-tokenizer": "*",
-                "php": ">=7.1"
+                "php": ">=7.4"
             },
             "require-dev": {
                 "ircmaxell/php-yacc": "^0.0.7",
-                "phpunit/phpunit": "^7.0 || ^8.0 || ^9.0"
+                "phpunit/phpunit": "^9.0"
             },
             "bin": [
                 "bin/php-parse"
@@ -295,7 +300,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.9-dev"
+                    "dev-master": "5.x-dev"
                 }
             },
             "autoload": {
@@ -319,9 +324,9 @@
             ],
             "support": {
                 "issues": "https://github.com/nikic/PHP-Parser/issues",
-                "source": "https://github.com/nikic/PHP-Parser/tree/v4.19.4"
+                "source": "https://github.com/nikic/PHP-Parser/tree/v5.7.0"
             },
-            "time": "2024-09-29T15:01:53+00:00"
+            "time": "2025-12-06T11:56:16+00:00"
         },
         {
             "name": "psr/cache",
@@ -526,28 +531,28 @@
         },
         {
             "name": "webmozart/assert",
-            "version": "1.11.0",
+            "version": "1.12.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/webmozarts/assert.git",
-                "reference": "11cb2199493b2f8a3b53e7f19068fc6aac760991"
+                "reference": "9be6926d8b485f55b9229203f962b51ed377ba68"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/webmozarts/assert/zipball/11cb2199493b2f8a3b53e7f19068fc6aac760991",
-                "reference": "11cb2199493b2f8a3b53e7f19068fc6aac760991",
+                "url": "https://api.github.com/repos/webmozarts/assert/zipball/9be6926d8b485f55b9229203f962b51ed377ba68",
+                "reference": "9be6926d8b485f55b9229203f962b51ed377ba68",
                 "shasum": ""
             },
             "require": {
                 "ext-ctype": "*",
+                "ext-date": "*",
+                "ext-filter": "*",
                 "php": "^7.2 || ^8.0"
             },
-            "conflict": {
-                "phpstan/phpstan": "<0.12.20",
-                "vimeo/psalm": "<4.6.1 || 4.6.2"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^8.5.13"
+            "suggest": {
+                "ext-intl": "",
+                "ext-simplexml": "",
+                "ext-spl": ""
             },
             "type": "library",
             "extra": {
@@ -578,51 +583,44 @@
             ],
             "support": {
                 "issues": "https://github.com/webmozarts/assert/issues",
-                "source": "https://github.com/webmozarts/assert/tree/1.11.0"
+                "source": "https://github.com/webmozarts/assert/tree/1.12.1"
             },
-            "time": "2022-06-03T18:03:27+00:00"
+            "time": "2025-10-29T15:56:20+00:00"
         }
     ],
     "packages-dev": [
         {
             "name": "amphp/amp",
-            "version": "v2.6.4",
+            "version": "v3.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/amphp/amp.git",
-                "reference": "ded3d9be08f526089eb7ee8d9f16a9768f9dec2d"
+                "reference": "fa0ab33a6f47a82929c38d03ca47ebb71086a93f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/amphp/amp/zipball/ded3d9be08f526089eb7ee8d9f16a9768f9dec2d",
-                "reference": "ded3d9be08f526089eb7ee8d9f16a9768f9dec2d",
+                "url": "https://api.github.com/repos/amphp/amp/zipball/fa0ab33a6f47a82929c38d03ca47ebb71086a93f",
+                "reference": "fa0ab33a6f47a82929c38d03ca47ebb71086a93f",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.1"
+                "php": ">=8.1",
+                "revolt/event-loop": "^1 || ^0.2"
             },
             "require-dev": {
-                "amphp/php-cs-fixer-config": "dev-master",
-                "amphp/phpunit-util": "^1",
-                "ext-json": "*",
-                "jetbrains/phpstorm-stubs": "^2019.3",
-                "phpunit/phpunit": "^7 | ^8 | ^9",
-                "react/promise": "^2",
-                "vimeo/psalm": "^3.12"
+                "amphp/php-cs-fixer-config": "^2",
+                "phpunit/phpunit": "^9",
+                "psalm/phar": "5.23.1"
             },
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.x-dev"
-                }
-            },
             "autoload": {
                 "files": [
-                    "lib/functions.php",
-                    "lib/Internal/functions.php"
+                    "src/functions.php",
+                    "src/Future/functions.php",
+                    "src/Internal/functions.php"
                 ],
                 "psr-4": {
-                    "Amp\\": "lib"
+                    "Amp\\": "src"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -630,10 +628,6 @@
                 "MIT"
             ],
             "authors": [
-                {
-                    "name": "Daniel Lowrey",
-                    "email": "rdlowrey@php.net"
-                },
                 {
                     "name": "Aaron Piotrowski",
                     "email": "aaron@trowski.com"
@@ -645,6 +639,10 @@
                 {
                     "name": "Niklas Keller",
                     "email": "me@kelunik.com"
+                },
+                {
+                    "name": "Daniel Lowrey",
+                    "email": "rdlowrey@php.net"
                 }
             ],
             "description": "A non-blocking concurrency framework for PHP applications.",
@@ -661,9 +659,8 @@
                 "promise"
             ],
             "support": {
-                "irc": "irc://irc.freenode.org/amphp",
                 "issues": "https://github.com/amphp/amp/issues",
-                "source": "https://github.com/amphp/amp/tree/v2.6.4"
+                "source": "https://github.com/amphp/amp/tree/v3.1.1"
             },
             "funding": [
                 {
@@ -671,41 +668,45 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-03-21T18:52:26+00:00"
+            "time": "2025-08-27T21:42:00+00:00"
         },
         {
             "name": "amphp/byte-stream",
-            "version": "v1.8.2",
+            "version": "v2.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/amphp/byte-stream.git",
-                "reference": "4f0e968ba3798a423730f567b1b50d3441c16ddc"
+                "reference": "55a6bd071aec26fa2a3e002618c20c35e3df1b46"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/amphp/byte-stream/zipball/4f0e968ba3798a423730f567b1b50d3441c16ddc",
-                "reference": "4f0e968ba3798a423730f567b1b50d3441c16ddc",
+                "url": "https://api.github.com/repos/amphp/byte-stream/zipball/55a6bd071aec26fa2a3e002618c20c35e3df1b46",
+                "reference": "55a6bd071aec26fa2a3e002618c20c35e3df1b46",
                 "shasum": ""
             },
             "require": {
-                "amphp/amp": "^2",
-                "php": ">=7.1"
+                "amphp/amp": "^3",
+                "amphp/parser": "^1.1",
+                "amphp/pipeline": "^1",
+                "amphp/serialization": "^1",
+                "amphp/sync": "^2",
+                "php": ">=8.1",
+                "revolt/event-loop": "^1 || ^0.2.3"
             },
             "require-dev": {
-                "amphp/php-cs-fixer-config": "dev-master",
-                "amphp/phpunit-util": "^1.4",
-                "friendsofphp/php-cs-fixer": "^2.3",
-                "jetbrains/phpstorm-stubs": "^2019.3",
-                "phpunit/phpunit": "^6 || ^7 || ^8",
-                "psalm/phar": "^3.11.4"
+                "amphp/php-cs-fixer-config": "^2",
+                "amphp/phpunit-util": "^3",
+                "phpunit/phpunit": "^9",
+                "psalm/phar": "5.22.1"
             },
             "type": "library",
             "autoload": {
                 "files": [
-                    "lib/functions.php"
+                    "src/functions.php",
+                    "src/Internal/functions.php"
                 ],
                 "psr-4": {
-                    "Amp\\ByteStream\\": "lib"
+                    "Amp\\ByteStream\\": "src"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -734,7 +735,7 @@
             ],
             "support": {
                 "issues": "https://github.com/amphp/byte-stream/issues",
-                "source": "https://github.com/amphp/byte-stream/tree/v1.8.2"
+                "source": "https://github.com/amphp/byte-stream/tree/v2.1.2"
             },
             "funding": [
                 {
@@ -742,44 +743,39 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-04-13T18:00:56+00:00"
+            "time": "2025-03-16T17:10:27+00:00"
         },
         {
-            "name": "composer/package-versions-deprecated",
-            "version": "1.11.99.5",
+            "name": "amphp/cache",
+            "version": "v2.0.1",
             "source": {
                 "type": "git",
-                "url": "https://github.com/composer/package-versions-deprecated.git",
-                "reference": "b4f54f74ef3453349c24a845d22392cd31e65f1d"
+                "url": "https://github.com/amphp/cache.git",
+                "reference": "46912e387e6aa94933b61ea1ead9cf7540b7797c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/package-versions-deprecated/zipball/b4f54f74ef3453349c24a845d22392cd31e65f1d",
-                "reference": "b4f54f74ef3453349c24a845d22392cd31e65f1d",
+                "url": "https://api.github.com/repos/amphp/cache/zipball/46912e387e6aa94933b61ea1ead9cf7540b7797c",
+                "reference": "46912e387e6aa94933b61ea1ead9cf7540b7797c",
                 "shasum": ""
             },
             "require": {
-                "composer-plugin-api": "^1.1.0 || ^2.0",
-                "php": "^7 || ^8"
-            },
-            "replace": {
-                "ocramius/package-versions": "1.11.99"
+                "amphp/amp": "^3",
+                "amphp/serialization": "^1",
+                "amphp/sync": "^2",
+                "php": ">=8.1",
+                "revolt/event-loop": "^1 || ^0.2"
             },
             "require-dev": {
-                "composer/composer": "^1.9.3 || ^2.0@dev",
-                "ext-zip": "^1.13",
-                "phpunit/phpunit": "^6.5 || ^7"
+                "amphp/php-cs-fixer-config": "^2",
+                "amphp/phpunit-util": "^3",
+                "phpunit/phpunit": "^9",
+                "psalm/phar": "^5.4"
             },
-            "type": "composer-plugin",
-            "extra": {
-                "class": "PackageVersions\\Installer",
-                "branch-alias": {
-                    "dev-master": "1.x-dev"
-                }
-            },
+            "type": "library",
             "autoload": {
                 "psr-4": {
-                    "PackageVersions\\": "src/PackageVersions"
+                    "Amp\\Cache\\": "src"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -788,34 +784,618 @@
             ],
             "authors": [
                 {
-                    "name": "Marco Pivetta",
-                    "email": "ocramius@gmail.com"
+                    "name": "Niklas Keller",
+                    "email": "me@kelunik.com"
                 },
                 {
-                    "name": "Jordi Boggiano",
-                    "email": "j.boggiano@seld.be"
+                    "name": "Aaron Piotrowski",
+                    "email": "aaron@trowski.com"
+                },
+                {
+                    "name": "Daniel Lowrey",
+                    "email": "rdlowrey@php.net"
                 }
             ],
-            "description": "Composer plugin that provides efficient querying for installed package versions (no runtime IO)",
+            "description": "A fiber-aware cache API based on Amp and Revolt.",
+            "homepage": "https://amphp.org/cache",
             "support": {
-                "issues": "https://github.com/composer/package-versions-deprecated/issues",
-                "source": "https://github.com/composer/package-versions-deprecated/tree/1.11.99.5"
+                "issues": "https://github.com/amphp/cache/issues",
+                "source": "https://github.com/amphp/cache/tree/v2.0.1"
             },
             "funding": [
                 {
-                    "url": "https://packagist.com",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/composer",
+                    "url": "https://github.com/amphp",
                     "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/composer/composer",
-                    "type": "tidelift"
                 }
             ],
-            "time": "2022-01-17T14:14:24+00:00"
+            "time": "2024-04-19T03:38:06+00:00"
+        },
+        {
+            "name": "amphp/dns",
+            "version": "v2.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/amphp/dns.git",
+                "reference": "78eb3db5fc69bf2fc0cb503c4fcba667bc223c71"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/amphp/dns/zipball/78eb3db5fc69bf2fc0cb503c4fcba667bc223c71",
+                "reference": "78eb3db5fc69bf2fc0cb503c4fcba667bc223c71",
+                "shasum": ""
+            },
+            "require": {
+                "amphp/amp": "^3",
+                "amphp/byte-stream": "^2",
+                "amphp/cache": "^2",
+                "amphp/parser": "^1",
+                "amphp/process": "^2",
+                "daverandom/libdns": "^2.0.2",
+                "ext-filter": "*",
+                "ext-json": "*",
+                "php": ">=8.1",
+                "revolt/event-loop": "^1 || ^0.2"
+            },
+            "require-dev": {
+                "amphp/php-cs-fixer-config": "^2",
+                "amphp/phpunit-util": "^3",
+                "phpunit/phpunit": "^9",
+                "psalm/phar": "5.20"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/functions.php"
+                ],
+                "psr-4": {
+                    "Amp\\Dns\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Chris Wright",
+                    "email": "addr@daverandom.com"
+                },
+                {
+                    "name": "Daniel Lowrey",
+                    "email": "rdlowrey@php.net"
+                },
+                {
+                    "name": "Bob Weinand",
+                    "email": "bobwei9@hotmail.com"
+                },
+                {
+                    "name": "Niklas Keller",
+                    "email": "me@kelunik.com"
+                },
+                {
+                    "name": "Aaron Piotrowski",
+                    "email": "aaron@trowski.com"
+                }
+            ],
+            "description": "Async DNS resolution for Amp.",
+            "homepage": "https://github.com/amphp/dns",
+            "keywords": [
+                "amp",
+                "amphp",
+                "async",
+                "client",
+                "dns",
+                "resolve"
+            ],
+            "support": {
+                "issues": "https://github.com/amphp/dns/issues",
+                "source": "https://github.com/amphp/dns/tree/v2.4.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/amphp",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-01-19T15:43:40+00:00"
+        },
+        {
+            "name": "amphp/parallel",
+            "version": "v2.3.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/amphp/parallel.git",
+                "reference": "296b521137a54d3a02425b464e5aee4c93db2c60"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/amphp/parallel/zipball/296b521137a54d3a02425b464e5aee4c93db2c60",
+                "reference": "296b521137a54d3a02425b464e5aee4c93db2c60",
+                "shasum": ""
+            },
+            "require": {
+                "amphp/amp": "^3",
+                "amphp/byte-stream": "^2",
+                "amphp/cache": "^2",
+                "amphp/parser": "^1",
+                "amphp/pipeline": "^1",
+                "amphp/process": "^2",
+                "amphp/serialization": "^1",
+                "amphp/socket": "^2",
+                "amphp/sync": "^2",
+                "php": ">=8.1",
+                "revolt/event-loop": "^1"
+            },
+            "require-dev": {
+                "amphp/php-cs-fixer-config": "^2",
+                "amphp/phpunit-util": "^3",
+                "phpunit/phpunit": "^9",
+                "psalm/phar": "^5.18"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/Context/functions.php",
+                    "src/Context/Internal/functions.php",
+                    "src/Ipc/functions.php",
+                    "src/Worker/functions.php"
+                ],
+                "psr-4": {
+                    "Amp\\Parallel\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Aaron Piotrowski",
+                    "email": "aaron@trowski.com"
+                },
+                {
+                    "name": "Niklas Keller",
+                    "email": "me@kelunik.com"
+                },
+                {
+                    "name": "Stephen Coakley",
+                    "email": "me@stephencoakley.com"
+                }
+            ],
+            "description": "Parallel processing component for Amp.",
+            "homepage": "https://github.com/amphp/parallel",
+            "keywords": [
+                "async",
+                "asynchronous",
+                "concurrent",
+                "multi-processing",
+                "multi-threading"
+            ],
+            "support": {
+                "issues": "https://github.com/amphp/parallel/issues",
+                "source": "https://github.com/amphp/parallel/tree/v2.3.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/amphp",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-11-15T06:23:42+00:00"
+        },
+        {
+            "name": "amphp/parser",
+            "version": "v1.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/amphp/parser.git",
+                "reference": "3cf1f8b32a0171d4b1bed93d25617637a77cded7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/amphp/parser/zipball/3cf1f8b32a0171d4b1bed93d25617637a77cded7",
+                "reference": "3cf1f8b32a0171d4b1bed93d25617637a77cded7",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.4"
+            },
+            "require-dev": {
+                "amphp/php-cs-fixer-config": "^2",
+                "phpunit/phpunit": "^9",
+                "psalm/phar": "^5.4"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Amp\\Parser\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Aaron Piotrowski",
+                    "email": "aaron@trowski.com"
+                },
+                {
+                    "name": "Niklas Keller",
+                    "email": "me@kelunik.com"
+                }
+            ],
+            "description": "A generator parser to make streaming parsers simple.",
+            "homepage": "https://github.com/amphp/parser",
+            "keywords": [
+                "async",
+                "non-blocking",
+                "parser",
+                "stream"
+            ],
+            "support": {
+                "issues": "https://github.com/amphp/parser/issues",
+                "source": "https://github.com/amphp/parser/tree/v1.1.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/amphp",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-03-21T19:16:53+00:00"
+        },
+        {
+            "name": "amphp/pipeline",
+            "version": "v1.2.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/amphp/pipeline.git",
+                "reference": "7b52598c2e9105ebcddf247fc523161581930367"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/amphp/pipeline/zipball/7b52598c2e9105ebcddf247fc523161581930367",
+                "reference": "7b52598c2e9105ebcddf247fc523161581930367",
+                "shasum": ""
+            },
+            "require": {
+                "amphp/amp": "^3",
+                "php": ">=8.1",
+                "revolt/event-loop": "^1"
+            },
+            "require-dev": {
+                "amphp/php-cs-fixer-config": "^2",
+                "amphp/phpunit-util": "^3",
+                "phpunit/phpunit": "^9",
+                "psalm/phar": "^5.18"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Amp\\Pipeline\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Aaron Piotrowski",
+                    "email": "aaron@trowski.com"
+                },
+                {
+                    "name": "Niklas Keller",
+                    "email": "me@kelunik.com"
+                }
+            ],
+            "description": "Asynchronous iterators and operators.",
+            "homepage": "https://amphp.org/pipeline",
+            "keywords": [
+                "amp",
+                "amphp",
+                "async",
+                "io",
+                "iterator",
+                "non-blocking"
+            ],
+            "support": {
+                "issues": "https://github.com/amphp/pipeline/issues",
+                "source": "https://github.com/amphp/pipeline/tree/v1.2.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/amphp",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-03-16T16:33:53+00:00"
+        },
+        {
+            "name": "amphp/process",
+            "version": "v2.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/amphp/process.git",
+                "reference": "52e08c09dec7511d5fbc1fb00d3e4e79fc77d58d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/amphp/process/zipball/52e08c09dec7511d5fbc1fb00d3e4e79fc77d58d",
+                "reference": "52e08c09dec7511d5fbc1fb00d3e4e79fc77d58d",
+                "shasum": ""
+            },
+            "require": {
+                "amphp/amp": "^3",
+                "amphp/byte-stream": "^2",
+                "amphp/sync": "^2",
+                "php": ">=8.1",
+                "revolt/event-loop": "^1 || ^0.2"
+            },
+            "require-dev": {
+                "amphp/php-cs-fixer-config": "^2",
+                "amphp/phpunit-util": "^3",
+                "phpunit/phpunit": "^9",
+                "psalm/phar": "^5.4"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/functions.php"
+                ],
+                "psr-4": {
+                    "Amp\\Process\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Bob Weinand",
+                    "email": "bobwei9@hotmail.com"
+                },
+                {
+                    "name": "Aaron Piotrowski",
+                    "email": "aaron@trowski.com"
+                },
+                {
+                    "name": "Niklas Keller",
+                    "email": "me@kelunik.com"
+                }
+            ],
+            "description": "A fiber-aware process manager based on Amp and Revolt.",
+            "homepage": "https://amphp.org/process",
+            "support": {
+                "issues": "https://github.com/amphp/process/issues",
+                "source": "https://github.com/amphp/process/tree/v2.0.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/amphp",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-04-19T03:13:44+00:00"
+        },
+        {
+            "name": "amphp/serialization",
+            "version": "v1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/amphp/serialization.git",
+                "reference": "693e77b2fb0b266c3c7d622317f881de44ae94a1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/amphp/serialization/zipball/693e77b2fb0b266c3c7d622317f881de44ae94a1",
+                "reference": "693e77b2fb0b266c3c7d622317f881de44ae94a1",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1"
+            },
+            "require-dev": {
+                "amphp/php-cs-fixer-config": "dev-master",
+                "phpunit/phpunit": "^9 || ^8 || ^7"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/functions.php"
+                ],
+                "psr-4": {
+                    "Amp\\Serialization\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Aaron Piotrowski",
+                    "email": "aaron@trowski.com"
+                },
+                {
+                    "name": "Niklas Keller",
+                    "email": "me@kelunik.com"
+                }
+            ],
+            "description": "Serialization tools for IPC and data storage in PHP.",
+            "homepage": "https://github.com/amphp/serialization",
+            "keywords": [
+                "async",
+                "asynchronous",
+                "serialization",
+                "serialize"
+            ],
+            "support": {
+                "issues": "https://github.com/amphp/serialization/issues",
+                "source": "https://github.com/amphp/serialization/tree/master"
+            },
+            "time": "2020-03-25T21:39:07+00:00"
+        },
+        {
+            "name": "amphp/socket",
+            "version": "v2.3.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/amphp/socket.git",
+                "reference": "58e0422221825b79681b72c50c47a930be7bf1e1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/amphp/socket/zipball/58e0422221825b79681b72c50c47a930be7bf1e1",
+                "reference": "58e0422221825b79681b72c50c47a930be7bf1e1",
+                "shasum": ""
+            },
+            "require": {
+                "amphp/amp": "^3",
+                "amphp/byte-stream": "^2",
+                "amphp/dns": "^2",
+                "ext-openssl": "*",
+                "kelunik/certificate": "^1.1",
+                "league/uri": "^6.5 | ^7",
+                "league/uri-interfaces": "^2.3 | ^7",
+                "php": ">=8.1",
+                "revolt/event-loop": "^1 || ^0.2"
+            },
+            "require-dev": {
+                "amphp/php-cs-fixer-config": "^2",
+                "amphp/phpunit-util": "^3",
+                "amphp/process": "^2",
+                "phpunit/phpunit": "^9",
+                "psalm/phar": "5.20"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/functions.php",
+                    "src/Internal/functions.php",
+                    "src/SocketAddress/functions.php"
+                ],
+                "psr-4": {
+                    "Amp\\Socket\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Daniel Lowrey",
+                    "email": "rdlowrey@gmail.com"
+                },
+                {
+                    "name": "Aaron Piotrowski",
+                    "email": "aaron@trowski.com"
+                },
+                {
+                    "name": "Niklas Keller",
+                    "email": "me@kelunik.com"
+                }
+            ],
+            "description": "Non-blocking socket connection / server implementations based on Amp and Revolt.",
+            "homepage": "https://github.com/amphp/socket",
+            "keywords": [
+                "amp",
+                "async",
+                "encryption",
+                "non-blocking",
+                "sockets",
+                "tcp",
+                "tls"
+            ],
+            "support": {
+                "issues": "https://github.com/amphp/socket/issues",
+                "source": "https://github.com/amphp/socket/tree/v2.3.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/amphp",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-04-21T14:33:03+00:00"
+        },
+        {
+            "name": "amphp/sync",
+            "version": "v2.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/amphp/sync.git",
+                "reference": "217097b785130d77cfcc58ff583cf26cd1770bf1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/amphp/sync/zipball/217097b785130d77cfcc58ff583cf26cd1770bf1",
+                "reference": "217097b785130d77cfcc58ff583cf26cd1770bf1",
+                "shasum": ""
+            },
+            "require": {
+                "amphp/amp": "^3",
+                "amphp/pipeline": "^1",
+                "amphp/serialization": "^1",
+                "php": ">=8.1",
+                "revolt/event-loop": "^1 || ^0.2"
+            },
+            "require-dev": {
+                "amphp/php-cs-fixer-config": "^2",
+                "amphp/phpunit-util": "^3",
+                "phpunit/phpunit": "^9",
+                "psalm/phar": "5.23"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/functions.php"
+                ],
+                "psr-4": {
+                    "Amp\\Sync\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Aaron Piotrowski",
+                    "email": "aaron@trowski.com"
+                },
+                {
+                    "name": "Niklas Keller",
+                    "email": "me@kelunik.com"
+                },
+                {
+                    "name": "Stephen Coakley",
+                    "email": "me@stephencoakley.com"
+                }
+            ],
+            "description": "Non-blocking synchronization primitives for PHP based on Amp and Revolt.",
+            "homepage": "https://github.com/amphp/sync",
+            "keywords": [
+                "async",
+                "asynchronous",
+                "mutex",
+                "semaphore",
+                "synchronization"
+            ],
+            "support": {
+                "issues": "https://github.com/amphp/sync/issues",
+                "source": "https://github.com/amphp/sync/tree/v2.3.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/amphp",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-08-03T19:31:26+00:00"
         },
         {
             "name": "composer/pcre",
@@ -1040,30 +1620,126 @@
             "time": "2024-05-06T16:37:16+00:00"
         },
         {
-            "name": "dealerdirect/phpcodesniffer-composer-installer",
-            "version": "v1.1.2",
+            "name": "danog/advanced-json-rpc",
+            "version": "v3.2.3",
             "source": {
                 "type": "git",
-                "url": "https://github.com/PHPCSStandards/composer-installer.git",
-                "reference": "e9cf5e4bbf7eeaf9ef5db34938942602838fc2b1"
+                "url": "https://github.com/danog/php-advanced-json-rpc.git",
+                "reference": "ae703ea7b4811797a10590b6078de05b3b33dd91"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCSStandards/composer-installer/zipball/e9cf5e4bbf7eeaf9ef5db34938942602838fc2b1",
-                "reference": "e9cf5e4bbf7eeaf9ef5db34938942602838fc2b1",
+                "url": "https://api.github.com/repos/danog/php-advanced-json-rpc/zipball/ae703ea7b4811797a10590b6078de05b3b33dd91",
+                "reference": "ae703ea7b4811797a10590b6078de05b3b33dd91",
+                "shasum": ""
+            },
+            "require": {
+                "netresearch/jsonmapper": "^5",
+                "php": ">=8.1",
+                "phpdocumentor/reflection-docblock": "^4.3.4 || ^5.0.0 || ^6"
+            },
+            "replace": {
+                "felixfbecker/php-advanced-json-rpc": "^3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "AdvancedJsonRpc\\": "lib/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "ISC"
+            ],
+            "authors": [
+                {
+                    "name": "Felix Becker",
+                    "email": "felix.b@outlook.com"
+                },
+                {
+                    "name": "Daniil Gentili",
+                    "email": "daniil@daniil.it"
+                }
+            ],
+            "description": "A more advanced JSONRPC implementation",
+            "support": {
+                "issues": "https://github.com/danog/php-advanced-json-rpc/issues",
+                "source": "https://github.com/danog/php-advanced-json-rpc/tree/v3.2.3"
+            },
+            "time": "2026-01-12T21:07:10+00:00"
+        },
+        {
+            "name": "daverandom/libdns",
+            "version": "v2.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/DaveRandom/LibDNS.git",
+                "reference": "b84c94e8fe6b7ee4aecfe121bfe3b6177d303c8a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/DaveRandom/LibDNS/zipball/b84c94e8fe6b7ee4aecfe121bfe3b6177d303c8a",
+                "reference": "b84c94e8fe6b7ee4aecfe121bfe3b6177d303c8a",
+                "shasum": ""
+            },
+            "require": {
+                "ext-ctype": "*",
+                "php": ">=7.1"
+            },
+            "suggest": {
+                "ext-intl": "Required for IDN support"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/functions.php"
+                ],
+                "psr-4": {
+                    "LibDNS\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "DNS protocol implementation written in pure PHP",
+            "keywords": [
+                "dns"
+            ],
+            "support": {
+                "issues": "https://github.com/DaveRandom/LibDNS/issues",
+                "source": "https://github.com/DaveRandom/LibDNS/tree/v2.1.0"
+            },
+            "time": "2024-04-12T12:12:48+00:00"
+        },
+        {
+            "name": "dealerdirect/phpcodesniffer-composer-installer",
+            "version": "v1.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHPCSStandards/composer-installer.git",
+                "reference": "845eb62303d2ca9b289ef216356568ccc075ffd1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHPCSStandards/composer-installer/zipball/845eb62303d2ca9b289ef216356568ccc075ffd1",
+                "reference": "845eb62303d2ca9b289ef216356568ccc075ffd1",
                 "shasum": ""
             },
             "require": {
                 "composer-plugin-api": "^2.2",
                 "php": ">=5.4",
-                "squizlabs/php_codesniffer": "^2.0 || ^3.1.0 || ^4.0"
+                "squizlabs/php_codesniffer": "^3.1.0 || ^4.0"
             },
             "require-dev": {
                 "composer/composer": "^2.2",
                 "ext-json": "*",
                 "ext-zip": "*",
                 "php-parallel-lint/php-parallel-lint": "^1.4.0",
-                "phpcompatibility/php-compatibility": "^9.0",
+                "phpcompatibility/php-compatibility": "^9.0 || ^10.0.0@dev",
                 "yoast/phpunit-polyfills": "^1.0"
             },
             "type": "composer-plugin",
@@ -1133,7 +1809,7 @@
                     "type": "thanks_dev"
                 }
             ],
-            "time": "2025-07-17T20:45:56+00:00"
+            "time": "2025-11-11T04:32:07+00:00"
         },
         {
             "name": "dnoegel/php-xdg-base-dir",
@@ -1219,51 +1895,6 @@
                 "source": "https://github.com/doctrine/deprecations/tree/1.1.5"
             },
             "time": "2025-04-07T20:06:18+00:00"
-        },
-        {
-            "name": "felixfbecker/advanced-json-rpc",
-            "version": "v3.2.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/felixfbecker/php-advanced-json-rpc.git",
-                "reference": "b5f37dbff9a8ad360ca341f3240dc1c168b45447"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/felixfbecker/php-advanced-json-rpc/zipball/b5f37dbff9a8ad360ca341f3240dc1c168b45447",
-                "reference": "b5f37dbff9a8ad360ca341f3240dc1c168b45447",
-                "shasum": ""
-            },
-            "require": {
-                "netresearch/jsonmapper": "^1.0 || ^2.0 || ^3.0 || ^4.0",
-                "php": "^7.1 || ^8.0",
-                "phpdocumentor/reflection-docblock": "^4.3.4 || ^5.0.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^7.0 || ^8.0"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "AdvancedJsonRpc\\": "lib/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "ISC"
-            ],
-            "authors": [
-                {
-                    "name": "Felix Becker",
-                    "email": "felix.b@outlook.com"
-                }
-            ],
-            "description": "A more advanced JSONRPC implementation",
-            "support": {
-                "issues": "https://github.com/felixfbecker/php-advanced-json-rpc/issues",
-                "source": "https://github.com/felixfbecker/php-advanced-json-rpc/tree/v3.2.1"
-            },
-            "time": "2021-06-11T22:34:44+00:00"
         },
         {
             "name": "felixfbecker/language-server-protocol",
@@ -1383,38 +2014,96 @@
             "time": "2025-08-14T07:29:31+00:00"
         },
         {
-            "name": "laminas/laminas-cli",
-            "version": "1.11.0",
+            "name": "kelunik/certificate",
+            "version": "v1.1.3",
             "source": {
                 "type": "git",
-                "url": "https://github.com/laminas/laminas-cli.git",
-                "reference": "159b48f896fb2502cb6618a95307b56a0f23e592"
+                "url": "https://github.com/kelunik/certificate.git",
+                "reference": "7e00d498c264d5eb4f78c69f41c8bd6719c0199e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-cli/zipball/159b48f896fb2502cb6618a95307b56a0f23e592",
-                "reference": "159b48f896fb2502cb6618a95307b56a0f23e592",
+                "url": "https://api.github.com/repos/kelunik/certificate/zipball/7e00d498c264d5eb4f78c69f41c8bd6719c0199e",
+                "reference": "7e00d498c264d5eb4f78c69f41c8bd6719c0199e",
+                "shasum": ""
+            },
+            "require": {
+                "ext-openssl": "*",
+                "php": ">=7.0"
+            },
+            "require-dev": {
+                "amphp/php-cs-fixer-config": "^2",
+                "phpunit/phpunit": "^6 | 7 | ^8 | ^9"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Kelunik\\Certificate\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Niklas Keller",
+                    "email": "me@kelunik.com"
+                }
+            ],
+            "description": "Access certificate details and transform between different formats.",
+            "keywords": [
+                "DER",
+                "certificate",
+                "certificates",
+                "openssl",
+                "pem",
+                "x509"
+            ],
+            "support": {
+                "issues": "https://github.com/kelunik/certificate/issues",
+                "source": "https://github.com/kelunik/certificate/tree/v1.1.3"
+            },
+            "time": "2023-02-03T21:26:53+00:00"
+        },
+        {
+            "name": "laminas/laminas-cli",
+            "version": "1.13.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laminas/laminas-cli.git",
+                "reference": "c84265f644c604f5a70bf5c8fcdb4b0e2aa115d5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laminas/laminas-cli/zipball/c84265f644c604f5a70bf5c8fcdb4b0e2aa115d5",
+                "reference": "c84265f644c604f5a70bf5c8fcdb4b0e2aa115d5",
                 "shasum": ""
             },
             "require": {
                 "composer-runtime-api": "^2.0.0",
-                "php": "~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0",
+                "php": "~8.2.0 || ~8.3.0 || ~8.4.0 || ~8.5.0",
                 "psr/container": "^1.0 || ^2.0",
                 "symfony/console": "^6.0 || ^7.0",
                 "symfony/event-dispatcher": "^6.0 || ^7.0",
-                "webmozart/assert": "^1.10"
+                "webmozart/assert": "^1.11"
             },
             "conflict": {
                 "amphp/amp": "<2.6.4"
             },
             "require-dev": {
-                "laminas/laminas-coding-standard": "^3.0.1",
+                "laminas/laminas-coding-standard": "^3.1.0",
                 "laminas/laminas-mvc": "^3.8.0",
-                "laminas/laminas-servicemanager": "^3.23.0",
+                "laminas/laminas-servicemanager": "^3.24.0",
                 "mikey179/vfsstream": "2.0.x-dev",
-                "phpunit/phpunit": "^10.5.38",
-                "psalm/plugin-phpunit": "^0.19.0",
-                "vimeo/psalm": "^5.26.1"
+                "phpunit/phpunit": "^11.5.42",
+                "psalm/plugin-phpunit": "^0.19.5",
+                "vimeo/psalm": "^6.13.1"
             },
             "bin": [
                 "bin/laminas"
@@ -1450,7 +2139,7 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2024-11-22T12:39:15+00:00"
+            "time": "2025-10-14T22:21:28+00:00"
         },
         {
             "name": "laminas/laminas-coding-standard",
@@ -1507,22 +2196,22 @@
         },
         {
             "name": "laminas/laminas-config-aggregator",
-            "version": "1.18.0",
+            "version": "1.19.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-config-aggregator.git",
-                "reference": "a5cc009f58daa4e1b968abd65972fa3a481c22c5"
+                "reference": "612343ce135c340fc667da3615e50d865a86b4d9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-config-aggregator/zipball/a5cc009f58daa4e1b968abd65972fa3a481c22c5",
-                "reference": "a5cc009f58daa4e1b968abd65972fa3a481c22c5",
+                "url": "https://api.github.com/repos/laminas/laminas-config-aggregator/zipball/612343ce135c340fc667da3615e50d865a86b4d9",
+                "reference": "612343ce135c340fc667da3615e50d865a86b4d9",
                 "shasum": ""
             },
             "require": {
                 "brick/varexporter": "^0.5.0 || ^0.4.0 || ^0.6.0",
                 "laminas/laminas-stdlib": "^3.18.0",
-                "php": "~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0",
+                "php": "~8.2.0 || ~8.3.0 || ~8.4.0 || ~8.5.0",
                 "webimpress/safe-writer": "^2.2.0"
             },
             "conflict": {
@@ -1530,11 +2219,11 @@
                 "zendframework/zend-config-aggregator": "*"
             },
             "require-dev": {
-                "laminas/laminas-coding-standard": "~3.0.1",
+                "laminas/laminas-coding-standard": "~3.1.0",
                 "laminas/laminas-config": "^3.10.1",
-                "phpunit/phpunit": "^10.5.45",
-                "psalm/plugin-phpunit": "^0.19.2",
-                "vimeo/psalm": "^6.8.6"
+                "phpunit/phpunit": "^11.5.42",
+                "psalm/plugin-phpunit": "^0.19.5",
+                "vimeo/psalm": "^6.13.1"
             },
             "suggest": {
                 "laminas/laminas-config": "Allows loading configuration from XML, INI, YAML, and JSON files",
@@ -1571,24 +2260,24 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2025-02-21T18:18:40+00:00"
+            "time": "2025-10-14T19:57:01+00:00"
         },
         {
             "name": "laminas/laminas-json",
-            "version": "3.7.1",
+            "version": "3.8.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-json.git",
-                "reference": "a0f9dca08e28f39a7a7a7a04370eb2f017369277"
+                "reference": "5448d357c4520d79f5caf4d46a1fe03ec8b8e4b0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-json/zipball/a0f9dca08e28f39a7a7a7a04370eb2f017369277",
-                "reference": "a0f9dca08e28f39a7a7a7a04370eb2f017369277",
+                "url": "https://api.github.com/repos/laminas/laminas-json/zipball/5448d357c4520d79f5caf4d46a1fe03ec8b8e4b0",
+                "reference": "5448d357c4520d79f5caf4d46a1fe03ec8b8e4b0",
                 "shasum": ""
             },
             "require": {
-                "php": "~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0"
+                "php": "^8.1.0"
             },
             "conflict": {
                 "zendframework/zend-json": "*"
@@ -1633,37 +2322,36 @@
                 }
             ],
             "abandoned": true,
-            "time": "2024-12-05T14:51:57+00:00"
+            "time": "2026-01-23T11:10:11+00:00"
         },
         {
             "name": "laminas/laminas-serializer",
-            "version": "3.1.0",
+            "version": "3.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-serializer.git",
-                "reference": "1322e7bee6c08ebeb31ebbad6028216a25aa0ba5"
+                "reference": "c8659b85ba2650ed339d027221ae937653b6c81e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-serializer/zipball/1322e7bee6c08ebeb31ebbad6028216a25aa0ba5",
-                "reference": "1322e7bee6c08ebeb31ebbad6028216a25aa0ba5",
+                "url": "https://api.github.com/repos/laminas/laminas-serializer/zipball/c8659b85ba2650ed339d027221ae937653b6c81e",
+                "reference": "c8659b85ba2650ed339d027221ae937653b6c81e",
                 "shasum": ""
             },
             "require": {
                 "laminas/laminas-json": "^3.1",
-                "laminas/laminas-servicemanager": "^4.1",
+                "laminas/laminas-servicemanager": "^4.5",
                 "laminas/laminas-stdlib": "^3.19",
-                "php": "~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0"
+                "php": "~8.2.0 || ~8.3.0 || ~8.4.0 || ~8.5.0"
             },
             "conflict": {
                 "zendframework/zend-serializer": "*"
             },
             "require-dev": {
-                "laminas/laminas-coding-standard": "~3.0.0",
-                "lctrs/psalm-psr-container-plugin": "^1.10",
-                "phpunit/phpunit": "^10.5.36",
+                "laminas/laminas-coding-standard": "~3.1.0",
+                "phpunit/phpunit": "^11.5.37",
                 "psalm/plugin-phpunit": "^0.19.0",
-                "vimeo/psalm": "^5.26.1"
+                "vimeo/psalm": "^6"
             },
             "type": "library",
             "extra": {
@@ -1701,7 +2389,189 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2024-10-15T11:24:57+00:00"
+            "time": "2026-01-30T00:13:45+00:00"
+        },
+        {
+            "name": "league/uri",
+            "version": "7.8.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/thephpleague/uri.git",
+                "reference": "4436c6ec8d458e4244448b069cc572d088230b76"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/thephpleague/uri/zipball/4436c6ec8d458e4244448b069cc572d088230b76",
+                "reference": "4436c6ec8d458e4244448b069cc572d088230b76",
+                "shasum": ""
+            },
+            "require": {
+                "league/uri-interfaces": "^7.8",
+                "php": "^8.1",
+                "psr/http-factory": "^1"
+            },
+            "conflict": {
+                "league/uri-schemes": "^1.0"
+            },
+            "suggest": {
+                "ext-bcmath": "to improve IPV4 host parsing",
+                "ext-dom": "to convert the URI into an HTML anchor tag",
+                "ext-fileinfo": "to create Data URI from file contennts",
+                "ext-gmp": "to improve IPV4 host parsing",
+                "ext-intl": "to handle IDN host with the best performance",
+                "ext-uri": "to use the PHP native URI class",
+                "jeremykendall/php-domain-parser": "to further parse the URI host and resolve its Public Suffix and Top Level Domain",
+                "league/uri-components": "to provide additional tools to manipulate URI objects components",
+                "league/uri-polyfill": "to backport the PHP URI extension for older versions of PHP",
+                "php-64bit": "to improve IPV4 host parsing",
+                "rowbot/url": "to handle URLs using the WHATWG URL Living Standard specification",
+                "symfony/polyfill-intl-idn": "to handle IDN host via the Symfony polyfill if ext-intl is not present"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "7.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "League\\Uri\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ignace Nyamagana Butera",
+                    "email": "nyamsprod@gmail.com",
+                    "homepage": "https://nyamsprod.com"
+                }
+            ],
+            "description": "URI manipulation library",
+            "homepage": "https://uri.thephpleague.com",
+            "keywords": [
+                "URN",
+                "data-uri",
+                "file-uri",
+                "ftp",
+                "hostname",
+                "http",
+                "https",
+                "middleware",
+                "parse_str",
+                "parse_url",
+                "psr-7",
+                "query-string",
+                "querystring",
+                "rfc2141",
+                "rfc3986",
+                "rfc3987",
+                "rfc6570",
+                "rfc8141",
+                "uri",
+                "uri-template",
+                "url",
+                "ws"
+            ],
+            "support": {
+                "docs": "https://uri.thephpleague.com",
+                "forum": "https://thephpleague.slack.com",
+                "issues": "https://github.com/thephpleague/uri-src/issues",
+                "source": "https://github.com/thephpleague/uri/tree/7.8.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sponsors/nyamsprod",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-01-14T17:24:56+00:00"
+        },
+        {
+            "name": "league/uri-interfaces",
+            "version": "7.8.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/thephpleague/uri-interfaces.git",
+                "reference": "c5c5cd056110fc8afaba29fa6b72a43ced42acd4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/thephpleague/uri-interfaces/zipball/c5c5cd056110fc8afaba29fa6b72a43ced42acd4",
+                "reference": "c5c5cd056110fc8afaba29fa6b72a43ced42acd4",
+                "shasum": ""
+            },
+            "require": {
+                "ext-filter": "*",
+                "php": "^8.1",
+                "psr/http-message": "^1.1 || ^2.0"
+            },
+            "suggest": {
+                "ext-bcmath": "to improve IPV4 host parsing",
+                "ext-gmp": "to improve IPV4 host parsing",
+                "ext-intl": "to handle IDN host with the best performance",
+                "php-64bit": "to improve IPV4 host parsing",
+                "rowbot/url": "to handle URLs using the WHATWG URL Living Standard specification",
+                "symfony/polyfill-intl-idn": "to handle IDN host via the Symfony polyfill if ext-intl is not present"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "7.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "League\\Uri\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ignace Nyamagana Butera",
+                    "email": "nyamsprod@gmail.com",
+                    "homepage": "https://nyamsprod.com"
+                }
+            ],
+            "description": "Common tools for parsing and resolving RFC3987/RFC3986 URI",
+            "homepage": "https://uri.thephpleague.com",
+            "keywords": [
+                "data-uri",
+                "file-uri",
+                "ftp",
+                "hostname",
+                "http",
+                "https",
+                "parse_str",
+                "parse_url",
+                "psr-7",
+                "query-string",
+                "querystring",
+                "rfc3986",
+                "rfc3987",
+                "rfc6570",
+                "uri",
+                "url",
+                "ws"
+            ],
+            "support": {
+                "docs": "https://uri.thephpleague.com",
+                "forum": "https://thephpleague.slack.com",
+                "issues": "https://github.com/thephpleague/uri-src/issues",
+                "source": "https://github.com/thephpleague/uri-interfaces/tree/7.8.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sponsors/nyamsprod",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-01-15T06:54:53+00:00"
         },
         {
             "name": "myclabs/deep-copy",
@@ -1765,16 +2635,16 @@
         },
         {
             "name": "netresearch/jsonmapper",
-            "version": "v4.5.0",
+            "version": "v5.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/cweiske/jsonmapper.git",
-                "reference": "8e76efb98ee8b6afc54687045e1b8dba55ac76e5"
+                "reference": "8c64d8d444a5d764c641ebe97e0e3bc72b25bf6c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/cweiske/jsonmapper/zipball/8e76efb98ee8b6afc54687045e1b8dba55ac76e5",
-                "reference": "8e76efb98ee8b6afc54687045e1b8dba55ac76e5",
+                "url": "https://api.github.com/repos/cweiske/jsonmapper/zipball/8c64d8d444a5d764c641ebe97e0e3bc72b25bf6c",
+                "reference": "8c64d8d444a5d764c641ebe97e0e3bc72b25bf6c",
                 "shasum": ""
             },
             "require": {
@@ -1810,9 +2680,9 @@
             "support": {
                 "email": "cweiske@cweiske.de",
                 "issues": "https://github.com/cweiske/jsonmapper/issues",
-                "source": "https://github.com/cweiske/jsonmapper/tree/v4.5.0"
+                "source": "https://github.com/cweiske/jsonmapper/tree/v5.0.0"
             },
-            "time": "2024-09-08T10:13:13+00:00"
+            "time": "2024-09-08T10:20:00+00:00"
         },
         {
             "name": "phar-io/manifest",
@@ -1987,16 +2857,16 @@
         },
         {
             "name": "phpdocumentor/reflection-docblock",
-            "version": "5.6.3",
+            "version": "6.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git",
-                "reference": "94f8051919d1b0369a6bcc7931d679a511c03fe9"
+                "reference": "2f5cbed597cb261d1ea458f3da3a9ad32e670b1e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/94f8051919d1b0369a6bcc7931d679a511c03fe9",
-                "reference": "94f8051919d1b0369a6bcc7931d679a511c03fe9",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/2f5cbed597cb261d1ea458f3da3a9ad32e670b1e",
+                "reference": "2f5cbed597cb261d1ea458f3da3a9ad32e670b1e",
                 "shasum": ""
             },
             "require": {
@@ -2004,9 +2874,9 @@
                 "ext-filter": "*",
                 "php": "^7.4 || ^8.0",
                 "phpdocumentor/reflection-common": "^2.2",
-                "phpdocumentor/type-resolver": "^1.7",
-                "phpstan/phpdoc-parser": "^1.7|^2.0",
-                "webmozart/assert": "^1.9.1"
+                "phpdocumentor/type-resolver": "^2.0",
+                "phpstan/phpdoc-parser": "^2.0",
+                "webmozart/assert": "^1.9.1 || ^2"
             },
             "require-dev": {
                 "mockery/mockery": "~1.3.5 || ~1.6.0",
@@ -2015,7 +2885,8 @@
                 "phpstan/phpstan-mockery": "^1.1",
                 "phpstan/phpstan-webmozart-assert": "^1.2",
                 "phpunit/phpunit": "^9.5",
-                "psalm/phar": "^5.26"
+                "psalm/phar": "^5.26",
+                "shipmonk/dead-code-detector": "^0.5.1"
             },
             "type": "library",
             "extra": {
@@ -2045,44 +2916,44 @@
             "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
             "support": {
                 "issues": "https://github.com/phpDocumentor/ReflectionDocBlock/issues",
-                "source": "https://github.com/phpDocumentor/ReflectionDocBlock/tree/5.6.3"
+                "source": "https://github.com/phpDocumentor/ReflectionDocBlock/tree/6.0.1"
             },
-            "time": "2025-08-01T19:43:32+00:00"
+            "time": "2026-01-20T15:30:42+00:00"
         },
         {
             "name": "phpdocumentor/type-resolver",
-            "version": "1.10.0",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/TypeResolver.git",
-                "reference": "679e3ce485b99e84c775d28e2e96fade9a7fb50a"
+                "reference": "327a05bbee54120d4786a0dc67aad30226ad4cf9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/679e3ce485b99e84c775d28e2e96fade9a7fb50a",
-                "reference": "679e3ce485b99e84c775d28e2e96fade9a7fb50a",
+                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/327a05bbee54120d4786a0dc67aad30226ad4cf9",
+                "reference": "327a05bbee54120d4786a0dc67aad30226ad4cf9",
                 "shasum": ""
             },
             "require": {
                 "doctrine/deprecations": "^1.0",
-                "php": "^7.3 || ^8.0",
+                "php": "^7.4 || ^8.0",
                 "phpdocumentor/reflection-common": "^2.0",
-                "phpstan/phpdoc-parser": "^1.18|^2.0"
+                "phpstan/phpdoc-parser": "^2.0"
             },
             "require-dev": {
                 "ext-tokenizer": "*",
                 "phpbench/phpbench": "^1.2",
-                "phpstan/extension-installer": "^1.1",
-                "phpstan/phpstan": "^1.8",
-                "phpstan/phpstan-phpunit": "^1.1",
+                "phpstan/extension-installer": "^1.4",
+                "phpstan/phpstan": "^2.1",
+                "phpstan/phpstan-phpunit": "^2.0",
                 "phpunit/phpunit": "^9.5",
-                "rector/rector": "^0.13.9",
-                "vimeo/psalm": "^4.25"
+                "psalm/phar": "^4"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-1.x": "1.x-dev"
+                    "dev-1.x": "1.x-dev",
+                    "dev-2.x": "2.x-dev"
                 }
             },
             "autoload": {
@@ -2103,22 +2974,22 @@
             "description": "A PSR-5 based resolver of Class names, Types and Structural Element Names",
             "support": {
                 "issues": "https://github.com/phpDocumentor/TypeResolver/issues",
-                "source": "https://github.com/phpDocumentor/TypeResolver/tree/1.10.0"
+                "source": "https://github.com/phpDocumentor/TypeResolver/tree/2.0.0"
             },
-            "time": "2024-11-09T15:12:26+00:00"
+            "time": "2026-01-06T21:53:42+00:00"
         },
         {
             "name": "phpstan/phpdoc-parser",
-            "version": "2.2.0",
+            "version": "2.3.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpdoc-parser.git",
-                "reference": "b9e61a61e39e02dd90944e9115241c7f7e76bfd8"
+                "reference": "a004701b11273a26cd7955a61d67a7f1e525a45a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/b9e61a61e39e02dd90944e9115241c7f7e76bfd8",
-                "reference": "b9e61a61e39e02dd90944e9115241c7f7e76bfd8",
+                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/a004701b11273a26cd7955a61d67a7f1e525a45a",
+                "reference": "a004701b11273a26cd7955a61d67a7f1e525a45a",
                 "shasum": ""
             },
             "require": {
@@ -2150,41 +3021,41 @@
             "description": "PHPDoc parser with support for nullable, intersection and generic types",
             "support": {
                 "issues": "https://github.com/phpstan/phpdoc-parser/issues",
-                "source": "https://github.com/phpstan/phpdoc-parser/tree/2.2.0"
+                "source": "https://github.com/phpstan/phpdoc-parser/tree/2.3.2"
             },
-            "time": "2025-07-13T07:04:09+00:00"
+            "time": "2026-01-25T14:56:51+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "10.1.16",
+            "version": "11.0.12",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "7e308268858ed6baedc8704a304727d20bc07c77"
+                "reference": "2c1ed04922802c15e1de5d7447b4856de949cf56"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/7e308268858ed6baedc8704a304727d20bc07c77",
-                "reference": "7e308268858ed6baedc8704a304727d20bc07c77",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/2c1ed04922802c15e1de5d7447b4856de949cf56",
+                "reference": "2c1ed04922802c15e1de5d7447b4856de949cf56",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
                 "ext-libxml": "*",
                 "ext-xmlwriter": "*",
-                "nikic/php-parser": "^4.19.1 || ^5.1.0",
-                "php": ">=8.1",
-                "phpunit/php-file-iterator": "^4.1.0",
-                "phpunit/php-text-template": "^3.0.1",
-                "sebastian/code-unit-reverse-lookup": "^3.0.0",
-                "sebastian/complexity": "^3.2.0",
-                "sebastian/environment": "^6.1.0",
-                "sebastian/lines-of-code": "^2.0.2",
-                "sebastian/version": "^4.0.1",
-                "theseer/tokenizer": "^1.2.3"
+                "nikic/php-parser": "^5.7.0",
+                "php": ">=8.2",
+                "phpunit/php-file-iterator": "^5.1.0",
+                "phpunit/php-text-template": "^4.0.1",
+                "sebastian/code-unit-reverse-lookup": "^4.0.1",
+                "sebastian/complexity": "^4.0.1",
+                "sebastian/environment": "^7.2.1",
+                "sebastian/lines-of-code": "^3.0.1",
+                "sebastian/version": "^5.0.2",
+                "theseer/tokenizer": "^1.3.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.1"
+                "phpunit/phpunit": "^11.5.46"
             },
             "suggest": {
                 "ext-pcov": "PHP extension that provides line coverage",
@@ -2193,7 +3064,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "10.1.x-dev"
+                    "dev-main": "11.0.x-dev"
                 }
             },
             "autoload": {
@@ -2222,40 +3093,52 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
                 "security": "https://github.com/sebastianbergmann/php-code-coverage/security/policy",
-                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/10.1.16"
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/11.0.12"
             },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/phpunit/php-code-coverage",
+                    "type": "tidelift"
                 }
             ],
-            "time": "2024-08-22T04:31:57+00:00"
+            "time": "2025-12-24T07:01:01+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
-            "version": "4.1.0",
+            "version": "5.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
-                "reference": "a95037b6d9e608ba092da1b23931e537cadc3c3c"
+                "reference": "118cfaaa8bc5aef3287bf315b6060b1174754af6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/a95037b6d9e608ba092da1b23931e537cadc3c3c",
-                "reference": "a95037b6d9e608ba092da1b23931e537cadc3c3c",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/118cfaaa8bc5aef3287bf315b6060b1174754af6",
+                "reference": "118cfaaa8bc5aef3287bf315b6060b1174754af6",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.1"
+                "php": ">=8.2"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.0"
+                "phpunit/phpunit": "^11.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "4.0-dev"
+                    "dev-main": "5.0-dev"
                 }
             },
             "autoload": {
@@ -2283,7 +3166,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-file-iterator/issues",
                 "security": "https://github.com/sebastianbergmann/php-file-iterator/security/policy",
-                "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/4.1.0"
+                "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/5.1.0"
             },
             "funding": [
                 {
@@ -2291,28 +3174,28 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-08-31T06:24:48+00:00"
+            "time": "2024-08-27T05:02:59+00:00"
         },
         {
             "name": "phpunit/php-invoker",
-            "version": "4.0.0",
+            "version": "5.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-invoker.git",
-                "reference": "f5e568ba02fa5ba0ddd0f618391d5a9ea50b06d7"
+                "reference": "c1ca3814734c07492b3d4c5f794f4b0995333da2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-invoker/zipball/f5e568ba02fa5ba0ddd0f618391d5a9ea50b06d7",
-                "reference": "f5e568ba02fa5ba0ddd0f618391d5a9ea50b06d7",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-invoker/zipball/c1ca3814734c07492b3d4c5f794f4b0995333da2",
+                "reference": "c1ca3814734c07492b3d4c5f794f4b0995333da2",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.1"
+                "php": ">=8.2"
             },
             "require-dev": {
                 "ext-pcntl": "*",
-                "phpunit/phpunit": "^10.0"
+                "phpunit/phpunit": "^11.0"
             },
             "suggest": {
                 "ext-pcntl": "*"
@@ -2320,7 +3203,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "4.0-dev"
+                    "dev-main": "5.0-dev"
                 }
             },
             "autoload": {
@@ -2346,7 +3229,8 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-invoker/issues",
-                "source": "https://github.com/sebastianbergmann/php-invoker/tree/4.0.0"
+                "security": "https://github.com/sebastianbergmann/php-invoker/security/policy",
+                "source": "https://github.com/sebastianbergmann/php-invoker/tree/5.0.1"
             },
             "funding": [
                 {
@@ -2354,32 +3238,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-02-03T06:56:09+00:00"
+            "time": "2024-07-03T05:07:44+00:00"
         },
         {
             "name": "phpunit/php-text-template",
-            "version": "3.0.1",
+            "version": "4.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-text-template.git",
-                "reference": "0c7b06ff49e3d5072f057eb1fa59258bf287a748"
+                "reference": "3e0404dc6b300e6bf56415467ebcb3fe4f33e964"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/0c7b06ff49e3d5072f057eb1fa59258bf287a748",
-                "reference": "0c7b06ff49e3d5072f057eb1fa59258bf287a748",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/3e0404dc6b300e6bf56415467ebcb3fe4f33e964",
+                "reference": "3e0404dc6b300e6bf56415467ebcb3fe4f33e964",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.1"
+                "php": ">=8.2"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.0"
+                "phpunit/phpunit": "^11.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "3.0-dev"
+                    "dev-main": "4.0-dev"
                 }
             },
             "autoload": {
@@ -2406,7 +3290,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-text-template/issues",
                 "security": "https://github.com/sebastianbergmann/php-text-template/security/policy",
-                "source": "https://github.com/sebastianbergmann/php-text-template/tree/3.0.1"
+                "source": "https://github.com/sebastianbergmann/php-text-template/tree/4.0.1"
             },
             "funding": [
                 {
@@ -2414,32 +3298,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-08-31T14:07:24+00:00"
+            "time": "2024-07-03T05:08:43+00:00"
         },
         {
             "name": "phpunit/php-timer",
-            "version": "6.0.0",
+            "version": "7.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-timer.git",
-                "reference": "e2a2d67966e740530f4a3343fe2e030ffdc1161d"
+                "reference": "3b415def83fbcb41f991d9ebf16ae4ad8b7837b3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/e2a2d67966e740530f4a3343fe2e030ffdc1161d",
-                "reference": "e2a2d67966e740530f4a3343fe2e030ffdc1161d",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/3b415def83fbcb41f991d9ebf16ae4ad8b7837b3",
+                "reference": "3b415def83fbcb41f991d9ebf16ae4ad8b7837b3",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.1"
+                "php": ">=8.2"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.0"
+                "phpunit/phpunit": "^11.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "6.0-dev"
+                    "dev-main": "7.0-dev"
                 }
             },
             "autoload": {
@@ -2465,7 +3349,8 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-timer/issues",
-                "source": "https://github.com/sebastianbergmann/php-timer/tree/6.0.0"
+                "security": "https://github.com/sebastianbergmann/php-timer/security/policy",
+                "source": "https://github.com/sebastianbergmann/php-timer/tree/7.0.1"
             },
             "funding": [
                 {
@@ -2473,20 +3358,20 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-02-03T06:57:52+00:00"
+            "time": "2024-07-03T05:09:35+00:00"
         },
         {
             "name": "phpunit/phpunit",
-            "version": "10.5.53",
+            "version": "11.5.50",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "32768472ebfb6969e6c7399f1c7b09009723f653"
+                "reference": "fdfc727f0fcacfeb8fcb30c7e5da173125b58be3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/32768472ebfb6969e6c7399f1c7b09009723f653",
-                "reference": "32768472ebfb6969e6c7399f1c7b09009723f653",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/fdfc727f0fcacfeb8fcb30c7e5da173125b58be3",
+                "reference": "fdfc727f0fcacfeb8fcb30c7e5da173125b58be3",
                 "shasum": ""
             },
             "require": {
@@ -2499,23 +3384,23 @@
                 "myclabs/deep-copy": "^1.13.4",
                 "phar-io/manifest": "^2.0.4",
                 "phar-io/version": "^3.2.1",
-                "php": ">=8.1",
-                "phpunit/php-code-coverage": "^10.1.16",
-                "phpunit/php-file-iterator": "^4.1.0",
-                "phpunit/php-invoker": "^4.0.0",
-                "phpunit/php-text-template": "^3.0.1",
-                "phpunit/php-timer": "^6.0.0",
-                "sebastian/cli-parser": "^2.0.1",
-                "sebastian/code-unit": "^2.0.0",
-                "sebastian/comparator": "^5.0.3",
-                "sebastian/diff": "^5.1.1",
-                "sebastian/environment": "^6.1.0",
-                "sebastian/exporter": "^5.1.2",
-                "sebastian/global-state": "^6.0.2",
-                "sebastian/object-enumerator": "^5.0.0",
-                "sebastian/recursion-context": "^5.0.1",
-                "sebastian/type": "^4.0.0",
-                "sebastian/version": "^4.0.1"
+                "php": ">=8.2",
+                "phpunit/php-code-coverage": "^11.0.12",
+                "phpunit/php-file-iterator": "^5.1.0",
+                "phpunit/php-invoker": "^5.0.1",
+                "phpunit/php-text-template": "^4.0.1",
+                "phpunit/php-timer": "^7.0.1",
+                "sebastian/cli-parser": "^3.0.2",
+                "sebastian/code-unit": "^3.0.3",
+                "sebastian/comparator": "^6.3.3",
+                "sebastian/diff": "^6.0.2",
+                "sebastian/environment": "^7.2.1",
+                "sebastian/exporter": "^6.3.2",
+                "sebastian/global-state": "^7.0.2",
+                "sebastian/object-enumerator": "^6.0.1",
+                "sebastian/type": "^5.1.3",
+                "sebastian/version": "^5.0.2",
+                "staabm/side-effects-detector": "^1.0.5"
             },
             "suggest": {
                 "ext-soap": "To be able to generate mocks based on WSDL files"
@@ -2526,7 +3411,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "10.5-dev"
+                    "dev-main": "11.5-dev"
                 }
             },
             "autoload": {
@@ -2558,7 +3443,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/10.5.53"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/11.5.50"
             },
             "funding": [
                 {
@@ -2582,38 +3467,36 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-08-20T14:40:06+00:00"
+            "time": "2026-01-27T05:59:18+00:00"
         },
         {
             "name": "psalm/plugin-phpunit",
-            "version": "0.19.0",
+            "version": "0.19.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/psalm/psalm-plugin-phpunit.git",
-                "reference": "e344eaaa27871e79c6cb97b9efe52a735f9d1966"
+                "reference": "143f9d5e049fffcdbc0da3fbb99f6149f9d3e2dc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/psalm/psalm-plugin-phpunit/zipball/e344eaaa27871e79c6cb97b9efe52a735f9d1966",
-                "reference": "e344eaaa27871e79c6cb97b9efe52a735f9d1966",
+                "url": "https://api.github.com/repos/psalm/psalm-plugin-phpunit/zipball/143f9d5e049fffcdbc0da3fbb99f6149f9d3e2dc",
+                "reference": "143f9d5e049fffcdbc0da3fbb99f6149f9d3e2dc",
                 "shasum": ""
             },
             "require": {
-                "composer/package-versions-deprecated": "^1.10",
-                "composer/semver": "^1.4 || ^2.0 || ^3.0",
                 "ext-simplexml": "*",
-                "php": "^7.4 || ^8.0",
-                "vimeo/psalm": "dev-master || ^5@beta || ^5.0"
+                "php": ">=8.1",
+                "vimeo/psalm": "dev-master || ^6.10.0"
             },
             "conflict": {
-                "phpunit/phpunit": "<7.5"
+                "phpspec/prophecy": "<1.20.0",
+                "phpspec/prophecy-phpunit": "<2.3.0",
+                "phpunit/phpunit": "<8.5.1"
             },
             "require-dev": {
-                "codeception/codeception": "^4.0.3",
                 "php": "^7.3 || ^8.0",
-                "phpunit/phpunit": "^7.5 || ^8.0 || ^9.0",
+                "phpunit/phpunit": "^10.0 || ^11.0 || ^12.0",
                 "squizlabs/php_codesniffer": "^3.3.1",
-                "weirdan/codeception-psalm-module": "^0.11.0",
                 "weirdan/prophecy-shim": "^1.0 || ^2.0"
             },
             "type": "psalm-plugin",
@@ -2640,9 +3523,9 @@
             "description": "Psalm plugin for PHPUnit",
             "support": {
                 "issues": "https://github.com/psalm/psalm-plugin-phpunit/issues",
-                "source": "https://github.com/psalm/psalm-plugin-phpunit/tree/0.19.0"
+                "source": "https://github.com/psalm/psalm-plugin-phpunit/tree/0.19.5"
             },
-            "time": "2024-03-15T10:43:15+00:00"
+            "time": "2025-03-31T18:49:55+00:00"
         },
         {
             "name": "psr/event-dispatcher",
@@ -2695,6 +3578,114 @@
             "time": "2019-01-08T18:20:26+00:00"
         },
         {
+            "name": "psr/http-factory",
+            "version": "1.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/http-factory.git",
+                "reference": "2b4765fddfe3b508ac62f829e852b1501d3f6e8a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/http-factory/zipball/2b4765fddfe3b508ac62f829e852b1501d3f6e8a",
+                "reference": "2b4765fddfe3b508ac62f829e852b1501d3f6e8a",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1",
+                "psr/http-message": "^1.0 || ^2.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Http\\Message\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "PSR-17: Common interfaces for PSR-7 HTTP message factories",
+            "keywords": [
+                "factory",
+                "http",
+                "message",
+                "psr",
+                "psr-17",
+                "psr-7",
+                "request",
+                "response"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/http-factory"
+            },
+            "time": "2024-04-15T12:06:14+00:00"
+        },
+        {
+            "name": "psr/http-message",
+            "version": "2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/http-message.git",
+                "reference": "402d35bcb92c70c026d1a6a9883f06b2ead23d71"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/http-message/zipball/402d35bcb92c70c026d1a6a9883f06b2ead23d71",
+                "reference": "402d35bcb92c70c026d1a6a9883f06b2ead23d71",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Http\\Message\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for HTTP messages",
+            "homepage": "https://github.com/php-fig/http-message",
+            "keywords": [
+                "http",
+                "http-message",
+                "psr",
+                "psr-7",
+                "request",
+                "response"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/http-message/tree/2.0"
+            },
+            "time": "2023-04-04T09:54:51+00:00"
+        },
+        {
             "name": "psr/log",
             "version": "3.0.2",
             "source": {
@@ -2745,29 +3736,101 @@
             "time": "2024-09-11T13:17:53+00:00"
         },
         {
-            "name": "sebastian/cli-parser",
-            "version": "2.0.1",
+            "name": "revolt/event-loop",
+            "version": "v1.0.8",
             "source": {
                 "type": "git",
-                "url": "https://github.com/sebastianbergmann/cli-parser.git",
-                "reference": "c34583b87e7b7a8055bf6c450c2c77ce32a24084"
+                "url": "https://github.com/revoltphp/event-loop.git",
+                "reference": "b6fc06dce8e9b523c9946138fa5e62181934f91c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/cli-parser/zipball/c34583b87e7b7a8055bf6c450c2c77ce32a24084",
-                "reference": "c34583b87e7b7a8055bf6c450c2c77ce32a24084",
+                "url": "https://api.github.com/repos/revoltphp/event-loop/zipball/b6fc06dce8e9b523c9946138fa5e62181934f91c",
+                "reference": "b6fc06dce8e9b523c9946138fa5e62181934f91c",
                 "shasum": ""
             },
             "require": {
                 "php": ">=8.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.0"
+                "ext-json": "*",
+                "jetbrains/phpstorm-stubs": "^2019.3",
+                "phpunit/phpunit": "^9",
+                "psalm/phar": "^5.15"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "2.0-dev"
+                    "dev-main": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Revolt\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Aaron Piotrowski",
+                    "email": "aaron@trowski.com"
+                },
+                {
+                    "name": "Cees-Jan Kiewiet",
+                    "email": "ceesjank@gmail.com"
+                },
+                {
+                    "name": "Christian Lück",
+                    "email": "christian@clue.engineering"
+                },
+                {
+                    "name": "Niklas Keller",
+                    "email": "me@kelunik.com"
+                }
+            ],
+            "description": "Rock-solid event loop for concurrent PHP applications.",
+            "keywords": [
+                "async",
+                "asynchronous",
+                "concurrency",
+                "event",
+                "event-loop",
+                "non-blocking",
+                "scheduler"
+            ],
+            "support": {
+                "issues": "https://github.com/revoltphp/event-loop/issues",
+                "source": "https://github.com/revoltphp/event-loop/tree/v1.0.8"
+            },
+            "time": "2025-08-27T21:33:23+00:00"
+        },
+        {
+            "name": "sebastian/cli-parser",
+            "version": "3.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/cli-parser.git",
+                "reference": "15c5dd40dc4f38794d383bb95465193f5e0ae180"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/cli-parser/zipball/15c5dd40dc4f38794d383bb95465193f5e0ae180",
+                "reference": "15c5dd40dc4f38794d383bb95465193f5e0ae180",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "3.0-dev"
                 }
             },
             "autoload": {
@@ -2791,7 +3854,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/cli-parser/issues",
                 "security": "https://github.com/sebastianbergmann/cli-parser/security/policy",
-                "source": "https://github.com/sebastianbergmann/cli-parser/tree/2.0.1"
+                "source": "https://github.com/sebastianbergmann/cli-parser/tree/3.0.2"
             },
             "funding": [
                 {
@@ -2799,32 +3862,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-03-02T07:12:49+00:00"
+            "time": "2024-07-03T04:41:36+00:00"
         },
         {
             "name": "sebastian/code-unit",
-            "version": "2.0.0",
+            "version": "3.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/code-unit.git",
-                "reference": "a81fee9eef0b7a76af11d121767abc44c104e503"
+                "reference": "54391c61e4af8078e5b276ab082b6d3c54c9ad64"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/code-unit/zipball/a81fee9eef0b7a76af11d121767abc44c104e503",
-                "reference": "a81fee9eef0b7a76af11d121767abc44c104e503",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit/zipball/54391c61e4af8078e5b276ab082b6d3c54c9ad64",
+                "reference": "54391c61e4af8078e5b276ab082b6d3c54c9ad64",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.1"
+                "php": ">=8.2"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.0"
+                "phpunit/phpunit": "^11.5"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "2.0-dev"
+                    "dev-main": "3.0-dev"
                 }
             },
             "autoload": {
@@ -2847,7 +3910,8 @@
             "homepage": "https://github.com/sebastianbergmann/code-unit",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/code-unit/issues",
-                "source": "https://github.com/sebastianbergmann/code-unit/tree/2.0.0"
+                "security": "https://github.com/sebastianbergmann/code-unit/security/policy",
+                "source": "https://github.com/sebastianbergmann/code-unit/tree/3.0.3"
             },
             "funding": [
                 {
@@ -2855,32 +3919,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-02-03T06:58:43+00:00"
+            "time": "2025-03-19T07:56:08+00:00"
         },
         {
             "name": "sebastian/code-unit-reverse-lookup",
-            "version": "3.0.0",
+            "version": "4.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/code-unit-reverse-lookup.git",
-                "reference": "5e3a687f7d8ae33fb362c5c0743794bbb2420a1d"
+                "reference": "183a9b2632194febd219bb9246eee421dad8d45e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/5e3a687f7d8ae33fb362c5c0743794bbb2420a1d",
-                "reference": "5e3a687f7d8ae33fb362c5c0743794bbb2420a1d",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/183a9b2632194febd219bb9246eee421dad8d45e",
+                "reference": "183a9b2632194febd219bb9246eee421dad8d45e",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.1"
+                "php": ">=8.2"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.0"
+                "phpunit/phpunit": "^11.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "3.0-dev"
+                    "dev-main": "4.0-dev"
                 }
             },
             "autoload": {
@@ -2902,7 +3966,8 @@
             "homepage": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/issues",
-                "source": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/tree/3.0.0"
+                "security": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/security/policy",
+                "source": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/tree/4.0.1"
             },
             "funding": [
                 {
@@ -2910,36 +3975,39 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-02-03T06:59:15+00:00"
+            "time": "2024-07-03T04:45:54+00:00"
         },
         {
             "name": "sebastian/comparator",
-            "version": "5.0.3",
+            "version": "6.3.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/comparator.git",
-                "reference": "a18251eb0b7a2dcd2f7aa3d6078b18545ef0558e"
+                "reference": "2c95e1e86cb8dd41beb8d502057d1081ccc8eca9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/a18251eb0b7a2dcd2f7aa3d6078b18545ef0558e",
-                "reference": "a18251eb0b7a2dcd2f7aa3d6078b18545ef0558e",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/2c95e1e86cb8dd41beb8d502057d1081ccc8eca9",
+                "reference": "2c95e1e86cb8dd41beb8d502057d1081ccc8eca9",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
                 "ext-mbstring": "*",
-                "php": ">=8.1",
-                "sebastian/diff": "^5.0",
-                "sebastian/exporter": "^5.0"
+                "php": ">=8.2",
+                "sebastian/diff": "^6.0",
+                "sebastian/exporter": "^6.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.5"
+                "phpunit/phpunit": "^11.4"
+            },
+            "suggest": {
+                "ext-bcmath": "For comparing BcMath\\Number objects"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "5.0-dev"
+                    "dev-main": "6.3-dev"
                 }
             },
             "autoload": {
@@ -2979,41 +4047,53 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/comparator/issues",
                 "security": "https://github.com/sebastianbergmann/comparator/security/policy",
-                "source": "https://github.com/sebastianbergmann/comparator/tree/5.0.3"
+                "source": "https://github.com/sebastianbergmann/comparator/tree/6.3.3"
             },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/comparator",
+                    "type": "tidelift"
                 }
             ],
-            "time": "2024-10-18T14:56:07+00:00"
+            "time": "2026-01-24T09:26:40+00:00"
         },
         {
             "name": "sebastian/complexity",
-            "version": "3.2.0",
+            "version": "4.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/complexity.git",
-                "reference": "68ff824baeae169ec9f2137158ee529584553799"
+                "reference": "ee41d384ab1906c68852636b6de493846e13e5a0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/complexity/zipball/68ff824baeae169ec9f2137158ee529584553799",
-                "reference": "68ff824baeae169ec9f2137158ee529584553799",
+                "url": "https://api.github.com/repos/sebastianbergmann/complexity/zipball/ee41d384ab1906c68852636b6de493846e13e5a0",
+                "reference": "ee41d384ab1906c68852636b6de493846e13e5a0",
                 "shasum": ""
             },
             "require": {
-                "nikic/php-parser": "^4.18 || ^5.0",
-                "php": ">=8.1"
+                "nikic/php-parser": "^5.0",
+                "php": ">=8.2"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.0"
+                "phpunit/phpunit": "^11.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "3.2-dev"
+                    "dev-main": "4.0-dev"
                 }
             },
             "autoload": {
@@ -3037,7 +4117,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/complexity/issues",
                 "security": "https://github.com/sebastianbergmann/complexity/security/policy",
-                "source": "https://github.com/sebastianbergmann/complexity/tree/3.2.0"
+                "source": "https://github.com/sebastianbergmann/complexity/tree/4.0.1"
             },
             "funding": [
                 {
@@ -3045,33 +4125,33 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-12-21T08:37:17+00:00"
+            "time": "2024-07-03T04:49:50+00:00"
         },
         {
             "name": "sebastian/diff",
-            "version": "5.1.1",
+            "version": "6.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/diff.git",
-                "reference": "c41e007b4b62af48218231d6c2275e4c9b975b2e"
+                "reference": "b4ccd857127db5d41a5b676f24b51371d76d8544"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/c41e007b4b62af48218231d6c2275e4c9b975b2e",
-                "reference": "c41e007b4b62af48218231d6c2275e4c9b975b2e",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/b4ccd857127db5d41a5b676f24b51371d76d8544",
+                "reference": "b4ccd857127db5d41a5b676f24b51371d76d8544",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.1"
+                "php": ">=8.2"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.0",
-                "symfony/process": "^6.4"
+                "phpunit/phpunit": "^11.0",
+                "symfony/process": "^4.2 || ^5"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "5.1-dev"
+                    "dev-main": "6.0-dev"
                 }
             },
             "autoload": {
@@ -3104,7 +4184,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/diff/issues",
                 "security": "https://github.com/sebastianbergmann/diff/security/policy",
-                "source": "https://github.com/sebastianbergmann/diff/tree/5.1.1"
+                "source": "https://github.com/sebastianbergmann/diff/tree/6.0.2"
             },
             "funding": [
                 {
@@ -3112,27 +4192,27 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-03-02T07:15:17+00:00"
+            "time": "2024-07-03T04:53:05+00:00"
         },
         {
             "name": "sebastian/environment",
-            "version": "6.1.0",
+            "version": "7.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/environment.git",
-                "reference": "8074dbcd93529b357029f5cc5058fd3e43666984"
+                "reference": "a5c75038693ad2e8d4b6c15ba2403532647830c4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/8074dbcd93529b357029f5cc5058fd3e43666984",
-                "reference": "8074dbcd93529b357029f5cc5058fd3e43666984",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/a5c75038693ad2e8d4b6c15ba2403532647830c4",
+                "reference": "a5c75038693ad2e8d4b6c15ba2403532647830c4",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.1"
+                "php": ">=8.2"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.0"
+                "phpunit/phpunit": "^11.3"
             },
             "suggest": {
                 "ext-posix": "*"
@@ -3140,7 +4220,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "6.1-dev"
+                    "dev-main": "7.2-dev"
                 }
             },
             "autoload": {
@@ -3168,42 +4248,54 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/environment/issues",
                 "security": "https://github.com/sebastianbergmann/environment/security/policy",
-                "source": "https://github.com/sebastianbergmann/environment/tree/6.1.0"
+                "source": "https://github.com/sebastianbergmann/environment/tree/7.2.1"
             },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/environment",
+                    "type": "tidelift"
                 }
             ],
-            "time": "2024-03-23T08:47:14+00:00"
+            "time": "2025-05-21T11:55:47+00:00"
         },
         {
             "name": "sebastian/exporter",
-            "version": "5.1.2",
+            "version": "6.3.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/exporter.git",
-                "reference": "955288482d97c19a372d3f31006ab3f37da47adf"
+                "reference": "70a298763b40b213ec087c51c739efcaa90bcd74"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/955288482d97c19a372d3f31006ab3f37da47adf",
-                "reference": "955288482d97c19a372d3f31006ab3f37da47adf",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/70a298763b40b213ec087c51c739efcaa90bcd74",
+                "reference": "70a298763b40b213ec087c51c739efcaa90bcd74",
                 "shasum": ""
             },
             "require": {
                 "ext-mbstring": "*",
-                "php": ">=8.1",
-                "sebastian/recursion-context": "^5.0"
+                "php": ">=8.2",
+                "sebastian/recursion-context": "^6.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.0"
+                "phpunit/phpunit": "^11.3"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "5.1-dev"
+                    "dev-main": "6.3-dev"
                 }
             },
             "autoload": {
@@ -3246,43 +4338,55 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/exporter/issues",
                 "security": "https://github.com/sebastianbergmann/exporter/security/policy",
-                "source": "https://github.com/sebastianbergmann/exporter/tree/5.1.2"
+                "source": "https://github.com/sebastianbergmann/exporter/tree/6.3.2"
             },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/exporter",
+                    "type": "tidelift"
                 }
             ],
-            "time": "2024-03-02T07:17:12+00:00"
+            "time": "2025-09-24T06:12:51+00:00"
         },
         {
             "name": "sebastian/global-state",
-            "version": "6.0.2",
+            "version": "7.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/global-state.git",
-                "reference": "987bafff24ecc4c9ac418cab1145b96dd6e9cbd9"
+                "reference": "3be331570a721f9a4b5917f4209773de17f747d7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/987bafff24ecc4c9ac418cab1145b96dd6e9cbd9",
-                "reference": "987bafff24ecc4c9ac418cab1145b96dd6e9cbd9",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/3be331570a721f9a4b5917f4209773de17f747d7",
+                "reference": "3be331570a721f9a4b5917f4209773de17f747d7",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.1",
-                "sebastian/object-reflector": "^3.0",
-                "sebastian/recursion-context": "^5.0"
+                "php": ">=8.2",
+                "sebastian/object-reflector": "^4.0",
+                "sebastian/recursion-context": "^6.0"
             },
             "require-dev": {
                 "ext-dom": "*",
-                "phpunit/phpunit": "^10.0"
+                "phpunit/phpunit": "^11.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "6.0-dev"
+                    "dev-main": "7.0-dev"
                 }
             },
             "autoload": {
@@ -3308,7 +4412,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/global-state/issues",
                 "security": "https://github.com/sebastianbergmann/global-state/security/policy",
-                "source": "https://github.com/sebastianbergmann/global-state/tree/6.0.2"
+                "source": "https://github.com/sebastianbergmann/global-state/tree/7.0.2"
             },
             "funding": [
                 {
@@ -3316,33 +4420,33 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-03-02T07:19:19+00:00"
+            "time": "2024-07-03T04:57:36+00:00"
         },
         {
             "name": "sebastian/lines-of-code",
-            "version": "2.0.2",
+            "version": "3.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/lines-of-code.git",
-                "reference": "856e7f6a75a84e339195d48c556f23be2ebf75d0"
+                "reference": "d36ad0d782e5756913e42ad87cb2890f4ffe467a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/lines-of-code/zipball/856e7f6a75a84e339195d48c556f23be2ebf75d0",
-                "reference": "856e7f6a75a84e339195d48c556f23be2ebf75d0",
+                "url": "https://api.github.com/repos/sebastianbergmann/lines-of-code/zipball/d36ad0d782e5756913e42ad87cb2890f4ffe467a",
+                "reference": "d36ad0d782e5756913e42ad87cb2890f4ffe467a",
                 "shasum": ""
             },
             "require": {
-                "nikic/php-parser": "^4.18 || ^5.0",
-                "php": ">=8.1"
+                "nikic/php-parser": "^5.0",
+                "php": ">=8.2"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.0"
+                "phpunit/phpunit": "^11.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "2.0-dev"
+                    "dev-main": "3.0-dev"
                 }
             },
             "autoload": {
@@ -3366,7 +4470,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/lines-of-code/issues",
                 "security": "https://github.com/sebastianbergmann/lines-of-code/security/policy",
-                "source": "https://github.com/sebastianbergmann/lines-of-code/tree/2.0.2"
+                "source": "https://github.com/sebastianbergmann/lines-of-code/tree/3.0.1"
             },
             "funding": [
                 {
@@ -3374,34 +4478,34 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-12-21T08:38:20+00:00"
+            "time": "2024-07-03T04:58:38+00:00"
         },
         {
             "name": "sebastian/object-enumerator",
-            "version": "5.0.0",
+            "version": "6.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/object-enumerator.git",
-                "reference": "202d0e344a580d7f7d04b3fafce6933e59dae906"
+                "reference": "f5b498e631a74204185071eb41f33f38d64608aa"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/202d0e344a580d7f7d04b3fafce6933e59dae906",
-                "reference": "202d0e344a580d7f7d04b3fafce6933e59dae906",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/f5b498e631a74204185071eb41f33f38d64608aa",
+                "reference": "f5b498e631a74204185071eb41f33f38d64608aa",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.1",
-                "sebastian/object-reflector": "^3.0",
-                "sebastian/recursion-context": "^5.0"
+                "php": ">=8.2",
+                "sebastian/object-reflector": "^4.0",
+                "sebastian/recursion-context": "^6.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.0"
+                "phpunit/phpunit": "^11.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "5.0-dev"
+                    "dev-main": "6.0-dev"
                 }
             },
             "autoload": {
@@ -3423,7 +4527,8 @@
             "homepage": "https://github.com/sebastianbergmann/object-enumerator/",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/object-enumerator/issues",
-                "source": "https://github.com/sebastianbergmann/object-enumerator/tree/5.0.0"
+                "security": "https://github.com/sebastianbergmann/object-enumerator/security/policy",
+                "source": "https://github.com/sebastianbergmann/object-enumerator/tree/6.0.1"
             },
             "funding": [
                 {
@@ -3431,32 +4536,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-02-03T07:08:32+00:00"
+            "time": "2024-07-03T05:00:13+00:00"
         },
         {
             "name": "sebastian/object-reflector",
-            "version": "3.0.0",
+            "version": "4.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/object-reflector.git",
-                "reference": "24ed13d98130f0e7122df55d06c5c4942a577957"
+                "reference": "6e1a43b411b2ad34146dee7524cb13a068bb35f9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/24ed13d98130f0e7122df55d06c5c4942a577957",
-                "reference": "24ed13d98130f0e7122df55d06c5c4942a577957",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/6e1a43b411b2ad34146dee7524cb13a068bb35f9",
+                "reference": "6e1a43b411b2ad34146dee7524cb13a068bb35f9",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.1"
+                "php": ">=8.2"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.0"
+                "phpunit/phpunit": "^11.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "3.0-dev"
+                    "dev-main": "4.0-dev"
                 }
             },
             "autoload": {
@@ -3478,7 +4583,8 @@
             "homepage": "https://github.com/sebastianbergmann/object-reflector/",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/object-reflector/issues",
-                "source": "https://github.com/sebastianbergmann/object-reflector/tree/3.0.0"
+                "security": "https://github.com/sebastianbergmann/object-reflector/security/policy",
+                "source": "https://github.com/sebastianbergmann/object-reflector/tree/4.0.1"
             },
             "funding": [
                 {
@@ -3486,32 +4592,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-02-03T07:06:18+00:00"
+            "time": "2024-07-03T05:01:32+00:00"
         },
         {
             "name": "sebastian/recursion-context",
-            "version": "5.0.1",
+            "version": "6.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/recursion-context.git",
-                "reference": "47e34210757a2f37a97dcd207d032e1b01e64c7a"
+                "reference": "f6458abbf32a6c8174f8f26261475dc133b3d9dc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/47e34210757a2f37a97dcd207d032e1b01e64c7a",
-                "reference": "47e34210757a2f37a97dcd207d032e1b01e64c7a",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/f6458abbf32a6c8174f8f26261475dc133b3d9dc",
+                "reference": "f6458abbf32a6c8174f8f26261475dc133b3d9dc",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.1"
+                "php": ">=8.2"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.5"
+                "phpunit/phpunit": "^11.3"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "5.0-dev"
+                    "dev-main": "6.0-dev"
                 }
             },
             "autoload": {
@@ -3542,7 +4648,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/recursion-context/issues",
                 "security": "https://github.com/sebastianbergmann/recursion-context/security/policy",
-                "source": "https://github.com/sebastianbergmann/recursion-context/tree/5.0.1"
+                "source": "https://github.com/sebastianbergmann/recursion-context/tree/6.0.3"
             },
             "funding": [
                 {
@@ -3562,32 +4668,32 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-08-10T07:50:56+00:00"
+            "time": "2025-08-13T04:42:22+00:00"
         },
         {
             "name": "sebastian/type",
-            "version": "4.0.0",
+            "version": "5.1.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/type.git",
-                "reference": "462699a16464c3944eefc02ebdd77882bd3925bf"
+                "reference": "f77d2d4e78738c98d9a68d2596fe5e8fa380f449"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/462699a16464c3944eefc02ebdd77882bd3925bf",
-                "reference": "462699a16464c3944eefc02ebdd77882bd3925bf",
+                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/f77d2d4e78738c98d9a68d2596fe5e8fa380f449",
+                "reference": "f77d2d4e78738c98d9a68d2596fe5e8fa380f449",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.1"
+                "php": ">=8.2"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.0"
+                "phpunit/phpunit": "^11.3"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "4.0-dev"
+                    "dev-main": "5.1-dev"
                 }
             },
             "autoload": {
@@ -3610,37 +4716,50 @@
             "homepage": "https://github.com/sebastianbergmann/type",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/type/issues",
-                "source": "https://github.com/sebastianbergmann/type/tree/4.0.0"
+                "security": "https://github.com/sebastianbergmann/type/security/policy",
+                "source": "https://github.com/sebastianbergmann/type/tree/5.1.3"
             },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/type",
+                    "type": "tidelift"
                 }
             ],
-            "time": "2023-02-03T07:10:45+00:00"
+            "time": "2025-08-09T06:55:48+00:00"
         },
         {
             "name": "sebastian/version",
-            "version": "4.0.1",
+            "version": "5.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/version.git",
-                "reference": "c51fa83a5d8f43f1402e3f32a005e6262244ef17"
+                "reference": "c687e3387b99f5b03b6caa64c74b63e2936ff874"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/c51fa83a5d8f43f1402e3f32a005e6262244ef17",
-                "reference": "c51fa83a5d8f43f1402e3f32a005e6262244ef17",
+                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/c687e3387b99f5b03b6caa64c74b63e2936ff874",
+                "reference": "c687e3387b99f5b03b6caa64c74b63e2936ff874",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.1"
+                "php": ">=8.2"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "4.0-dev"
+                    "dev-main": "5.0-dev"
                 }
             },
             "autoload": {
@@ -3663,7 +4782,8 @@
             "homepage": "https://github.com/sebastianbergmann/version",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/version/issues",
-                "source": "https://github.com/sebastianbergmann/version/tree/4.0.1"
+                "security": "https://github.com/sebastianbergmann/version/security/policy",
+                "source": "https://github.com/sebastianbergmann/version/tree/5.0.2"
             },
             "funding": [
                 {
@@ -3671,36 +4791,36 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-02-07T11:34:05+00:00"
+            "time": "2024-10-09T05:16:32+00:00"
         },
         {
             "name": "slevomat/coding-standard",
-            "version": "8.20.0",
+            "version": "8.22.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/slevomat/coding-standard.git",
-                "reference": "b4f9f02edd4e6a586777f0cabe8d05574323f3eb"
+                "reference": "1dd80bf3b93692bedb21a6623c496887fad05fec"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/slevomat/coding-standard/zipball/b4f9f02edd4e6a586777f0cabe8d05574323f3eb",
-                "reference": "b4f9f02edd4e6a586777f0cabe8d05574323f3eb",
+                "url": "https://api.github.com/repos/slevomat/coding-standard/zipball/1dd80bf3b93692bedb21a6623c496887fad05fec",
+                "reference": "1dd80bf3b93692bedb21a6623c496887fad05fec",
                 "shasum": ""
             },
             "require": {
                 "dealerdirect/phpcodesniffer-composer-installer": "^0.6.2 || ^0.7 || ^1.1.2",
                 "php": "^7.4 || ^8.0",
-                "phpstan/phpdoc-parser": "^2.2.0",
-                "squizlabs/php_codesniffer": "^3.13.2"
+                "phpstan/phpdoc-parser": "^2.3.0",
+                "squizlabs/php_codesniffer": "^3.13.4"
             },
             "require-dev": {
                 "phing/phing": "3.0.1|3.1.0",
                 "php-parallel-lint/php-parallel-lint": "1.4.0",
-                "phpstan/phpstan": "2.1.19",
+                "phpstan/phpstan": "2.1.24",
                 "phpstan/phpstan-deprecation-rules": "2.0.3",
                 "phpstan/phpstan-phpunit": "2.0.7",
                 "phpstan/phpstan-strict-rules": "2.0.6",
-                "phpunit/phpunit": "9.6.8|10.5.48|11.4.4|11.5.27|12.2.7"
+                "phpunit/phpunit": "9.6.8|10.5.48|11.4.4|11.5.36|12.3.10"
             },
             "type": "phpcodesniffer-standard",
             "extra": {
@@ -3724,7 +4844,7 @@
             ],
             "support": {
                 "issues": "https://github.com/slevomat/coding-standard/issues",
-                "source": "https://github.com/slevomat/coding-standard/tree/8.20.0"
+                "source": "https://github.com/slevomat/coding-standard/tree/8.22.1"
             },
             "funding": [
                 {
@@ -3736,20 +4856,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-07-26T15:35:10+00:00"
+            "time": "2025-09-13T08:53:30+00:00"
         },
         {
             "name": "spatie/array-to-xml",
-            "version": "3.4.0",
+            "version": "3.4.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spatie/array-to-xml.git",
-                "reference": "7dcfc67d60b0272926dabad1ec01f6b8a5fb5e67"
+                "reference": "88b2f3852a922dd73177a68938f8eb2ec70c7224"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spatie/array-to-xml/zipball/7dcfc67d60b0272926dabad1ec01f6b8a5fb5e67",
-                "reference": "7dcfc67d60b0272926dabad1ec01f6b8a5fb5e67",
+                "url": "https://api.github.com/repos/spatie/array-to-xml/zipball/88b2f3852a922dd73177a68938f8eb2ec70c7224",
+                "reference": "88b2f3852a922dd73177a68938f8eb2ec70c7224",
                 "shasum": ""
             },
             "require": {
@@ -3792,7 +4912,7 @@
                 "xml"
             ],
             "support": {
-                "source": "https://github.com/spatie/array-to-xml/tree/3.4.0"
+                "source": "https://github.com/spatie/array-to-xml/tree/3.4.4"
             },
             "funding": [
                 {
@@ -3804,20 +4924,20 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-12-16T12:45:15+00:00"
+            "time": "2025-12-15T09:00:41+00:00"
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.13.2",
+            "version": "3.13.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCSStandards/PHP_CodeSniffer.git",
-                "reference": "5b5e3821314f947dd040c70f7992a64eac89025c"
+                "reference": "0ca86845ce43291e8f5692c7356fccf3bcf02bf4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/5b5e3821314f947dd040c70f7992a64eac89025c",
-                "reference": "5b5e3821314f947dd040c70f7992a64eac89025c",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/0ca86845ce43291e8f5692c7356fccf3bcf02bf4",
+                "reference": "0ca86845ce43291e8f5692c7356fccf3bcf02bf4",
                 "shasum": ""
             },
             "require": {
@@ -3834,11 +4954,6 @@
                 "bin/phpcs"
             ],
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "3.x-dev"
-                }
-            },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "BSD-3-Clause"
@@ -3888,51 +5003,103 @@
                     "type": "thanks_dev"
                 }
             ],
-            "time": "2025-06-17T22:17:01+00:00"
+            "time": "2025-11-04T16:30:35+00:00"
         },
         {
-            "name": "symfony/console",
-            "version": "v6.4.24",
+            "name": "staabm/side-effects-detector",
+            "version": "1.0.5",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/console.git",
-                "reference": "59266a5bf6a596e3e0844fd95e6ad7ea3c1d3350"
+                "url": "https://github.com/staabm/side-effects-detector.git",
+                "reference": "d8334211a140ce329c13726d4a715adbddd0a163"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/59266a5bf6a596e3e0844fd95e6ad7ea3c1d3350",
-                "reference": "59266a5bf6a596e3e0844fd95e6ad7ea3c1d3350",
+                "url": "https://api.github.com/repos/staabm/side-effects-detector/zipball/d8334211a140ce329c13726d4a715adbddd0a163",
+                "reference": "d8334211a140ce329c13726d4a715adbddd0a163",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.1",
+                "ext-tokenizer": "*",
+                "php": "^7.4 || ^8.0"
+            },
+            "require-dev": {
+                "phpstan/extension-installer": "^1.4.3",
+                "phpstan/phpstan": "^1.12.6",
+                "phpunit/phpunit": "^9.6.21",
+                "symfony/var-dumper": "^5.4.43",
+                "tomasvotruba/type-coverage": "1.0.0",
+                "tomasvotruba/unused-public": "1.0.0"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "lib/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "A static analysis tool to detect side effects in PHP code",
+            "keywords": [
+                "static analysis"
+            ],
+            "support": {
+                "issues": "https://github.com/staabm/side-effects-detector/issues",
+                "source": "https://github.com/staabm/side-effects-detector/tree/1.0.5"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/staabm",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-10-20T05:08:20+00:00"
+        },
+        {
+            "name": "symfony/console",
+            "version": "v7.4.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/console.git",
+                "reference": "41e38717ac1dd7a46b6bda7d6a82af2d98a78894"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/console/zipball/41e38717ac1dd7a46b6bda7d6a82af2d98a78894",
+                "reference": "41e38717ac1dd7a46b6bda7d6a82af2d98a78894",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2",
                 "symfony/deprecation-contracts": "^2.5|^3",
                 "symfony/polyfill-mbstring": "~1.0",
                 "symfony/service-contracts": "^2.5|^3",
-                "symfony/string": "^5.4|^6.0|^7.0"
+                "symfony/string": "^7.2|^8.0"
             },
             "conflict": {
-                "symfony/dependency-injection": "<5.4",
-                "symfony/dotenv": "<5.4",
-                "symfony/event-dispatcher": "<5.4",
-                "symfony/lock": "<5.4",
-                "symfony/process": "<5.4"
+                "symfony/dependency-injection": "<6.4",
+                "symfony/dotenv": "<6.4",
+                "symfony/event-dispatcher": "<6.4",
+                "symfony/lock": "<6.4",
+                "symfony/process": "<6.4"
             },
             "provide": {
                 "psr/log-implementation": "1.0|2.0|3.0"
             },
             "require-dev": {
                 "psr/log": "^1|^2|^3",
-                "symfony/config": "^5.4|^6.0|^7.0",
-                "symfony/dependency-injection": "^5.4|^6.0|^7.0",
-                "symfony/event-dispatcher": "^5.4|^6.0|^7.0",
-                "symfony/http-foundation": "^6.4|^7.0",
-                "symfony/http-kernel": "^6.4|^7.0",
-                "symfony/lock": "^5.4|^6.0|^7.0",
-                "symfony/messenger": "^5.4|^6.0|^7.0",
-                "symfony/process": "^5.4|^6.0|^7.0",
-                "symfony/stopwatch": "^5.4|^6.0|^7.0",
-                "symfony/var-dumper": "^5.4|^6.0|^7.0"
+                "symfony/config": "^6.4|^7.0|^8.0",
+                "symfony/dependency-injection": "^6.4|^7.0|^8.0",
+                "symfony/event-dispatcher": "^6.4|^7.0|^8.0",
+                "symfony/http-foundation": "^6.4|^7.0|^8.0",
+                "symfony/http-kernel": "^6.4|^7.0|^8.0",
+                "symfony/lock": "^6.4|^7.0|^8.0",
+                "symfony/messenger": "^6.4|^7.0|^8.0",
+                "symfony/process": "^6.4|^7.0|^8.0",
+                "symfony/stopwatch": "^6.4|^7.0|^8.0",
+                "symfony/var-dumper": "^6.4|^7.0|^8.0"
             },
             "type": "library",
             "autoload": {
@@ -3966,7 +5133,7 @@
                 "terminal"
             ],
             "support": {
-                "source": "https://github.com/symfony/console/tree/v6.4.24"
+                "source": "https://github.com/symfony/console/tree/v7.4.4"
             },
             "funding": [
                 {
@@ -3986,7 +5153,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-07-30T10:38:54+00:00"
+            "time": "2026-01-13T11:36:38+00:00"
         },
         {
             "name": "symfony/deprecation-contracts",
@@ -4057,24 +5224,24 @@
         },
         {
             "name": "symfony/event-dispatcher",
-            "version": "v6.4.24",
+            "version": "v7.4.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/event-dispatcher.git",
-                "reference": "307a09d8d7228d14a05e5e05b95fffdacab032b2"
+                "reference": "dc2c0eba1af673e736bb851d747d266108aea746"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/307a09d8d7228d14a05e5e05b95fffdacab032b2",
-                "reference": "307a09d8d7228d14a05e5e05b95fffdacab032b2",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/dc2c0eba1af673e736bb851d747d266108aea746",
+                "reference": "dc2c0eba1af673e736bb851d747d266108aea746",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.1",
+                "php": ">=8.2",
                 "symfony/event-dispatcher-contracts": "^2.5|^3"
             },
             "conflict": {
-                "symfony/dependency-injection": "<5.4",
+                "symfony/dependency-injection": "<6.4",
                 "symfony/service-contracts": "<2.5"
             },
             "provide": {
@@ -4083,13 +5250,14 @@
             },
             "require-dev": {
                 "psr/log": "^1|^2|^3",
-                "symfony/config": "^5.4|^6.0|^7.0",
-                "symfony/dependency-injection": "^5.4|^6.0|^7.0",
-                "symfony/error-handler": "^5.4|^6.0|^7.0",
-                "symfony/expression-language": "^5.4|^6.0|^7.0",
-                "symfony/http-foundation": "^5.4|^6.0|^7.0",
+                "symfony/config": "^6.4|^7.0|^8.0",
+                "symfony/dependency-injection": "^6.4|^7.0|^8.0",
+                "symfony/error-handler": "^6.4|^7.0|^8.0",
+                "symfony/expression-language": "^6.4|^7.0|^8.0",
+                "symfony/framework-bundle": "^6.4|^7.0|^8.0",
+                "symfony/http-foundation": "^6.4|^7.0|^8.0",
                 "symfony/service-contracts": "^2.5|^3",
-                "symfony/stopwatch": "^5.4|^6.0|^7.0"
+                "symfony/stopwatch": "^6.4|^7.0|^8.0"
             },
             "type": "library",
             "autoload": {
@@ -4117,7 +5285,7 @@
             "description": "Provides tools that allow your application components to communicate with each other by dispatching events and listening to them",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/event-dispatcher/tree/v6.4.24"
+                "source": "https://github.com/symfony/event-dispatcher/tree/v7.4.4"
             },
             "funding": [
                 {
@@ -4137,7 +5305,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-07-10T08:14:14+00:00"
+            "time": "2026-01-05T11:45:34+00:00"
         },
         {
             "name": "symfony/event-dispatcher-contracts",
@@ -4217,25 +5385,25 @@
         },
         {
             "name": "symfony/filesystem",
-            "version": "v6.4.24",
+            "version": "v7.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/filesystem.git",
-                "reference": "75ae2edb7cdcc0c53766c30b0a2512b8df574bd8"
+                "reference": "d551b38811096d0be9c4691d406991b47c0c630a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/filesystem/zipball/75ae2edb7cdcc0c53766c30b0a2512b8df574bd8",
-                "reference": "75ae2edb7cdcc0c53766c30b0a2512b8df574bd8",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/d551b38811096d0be9c4691d406991b47c0c630a",
+                "reference": "d551b38811096d0be9c4691d406991b47c0c630a",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.1",
+                "php": ">=8.2",
                 "symfony/polyfill-ctype": "~1.8",
                 "symfony/polyfill-mbstring": "~1.8"
             },
             "require-dev": {
-                "symfony/process": "^5.4|^6.4|^7.0"
+                "symfony/process": "^6.4|^7.0|^8.0"
             },
             "type": "library",
             "autoload": {
@@ -4263,7 +5431,7 @@
             "description": "Provides basic utilities for the filesystem",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/filesystem/tree/v6.4.24"
+                "source": "https://github.com/symfony/filesystem/tree/v7.4.0"
             },
             "funding": [
                 {
@@ -4283,7 +5451,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-07-10T08:14:14+00:00"
+            "time": "2025-11-27T13:27:24+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
@@ -4621,17 +5789,97 @@
             "time": "2024-12-23T08:48:59+00:00"
         },
         {
-            "name": "symfony/service-contracts",
-            "version": "v3.6.0",
+            "name": "symfony/polyfill-php84",
+            "version": "v1.33.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/service-contracts.git",
-                "reference": "f021b05a130d35510bd6b25fe9053c2a8a15d5d4"
+                "url": "https://github.com/symfony/polyfill-php84.git",
+                "reference": "d8ced4d875142b6a7426000426b8abc631d6b191"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/f021b05a130d35510bd6b25fe9053c2a8a15d5d4",
-                "reference": "f021b05a130d35510bd6b25fe9053c2a8a15d5d4",
+                "url": "https://api.github.com/repos/symfony/polyfill-php84/zipball/d8ced4d875142b6a7426000426b8abc631d6b191",
+                "reference": "d8ced4d875142b6a7426000426b8abc631d6b191",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Php84\\": ""
+                },
+                "classmap": [
+                    "Resources/stubs"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill backporting some PHP 8.4+ features to lower PHP versions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-php84/tree/v1.33.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-06-24T13:30:11+00:00"
+        },
+        {
+            "name": "symfony/service-contracts",
+            "version": "v3.6.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/service-contracts.git",
+                "reference": "45112560a3ba2d715666a509a0bc9521d10b6c43"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/45112560a3ba2d715666a509a0bc9521d10b6c43",
+                "reference": "45112560a3ba2d715666a509a0bc9521d10b6c43",
                 "shasum": ""
             },
             "require": {
@@ -4685,7 +5933,7 @@
                 "standards"
             ],
             "support": {
-                "source": "https://github.com/symfony/service-contracts/tree/v3.6.0"
+                "source": "https://github.com/symfony/service-contracts/tree/v3.6.1"
             },
             "funding": [
                 {
@@ -4697,30 +5945,35 @@
                     "type": "github"
                 },
                 {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
                     "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-04-25T09:37:31+00:00"
+            "time": "2025-07-15T11:30:57+00:00"
         },
         {
             "name": "symfony/string",
-            "version": "v6.4.24",
+            "version": "v7.4.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/string.git",
-                "reference": "f0ce0bd36a3accb4a225435be077b4b4875587f4"
+                "reference": "1c4b10461bf2ec27537b5f36105337262f5f5d6f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/string/zipball/f0ce0bd36a3accb4a225435be077b4b4875587f4",
-                "reference": "f0ce0bd36a3accb4a225435be077b4b4875587f4",
+                "url": "https://api.github.com/repos/symfony/string/zipball/1c4b10461bf2ec27537b5f36105337262f5f5d6f",
+                "reference": "1c4b10461bf2ec27537b5f36105337262f5f5d6f",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.1",
+                "php": ">=8.2",
+                "symfony/deprecation-contracts": "^2.5|^3.0",
                 "symfony/polyfill-ctype": "~1.8",
-                "symfony/polyfill-intl-grapheme": "~1.0",
+                "symfony/polyfill-intl-grapheme": "~1.33",
                 "symfony/polyfill-intl-normalizer": "~1.0",
                 "symfony/polyfill-mbstring": "~1.0"
             },
@@ -4728,11 +5981,11 @@
                 "symfony/translation-contracts": "<2.5"
             },
             "require-dev": {
-                "symfony/error-handler": "^5.4|^6.0|^7.0",
-                "symfony/http-client": "^5.4|^6.0|^7.0",
-                "symfony/intl": "^6.2|^7.0",
+                "symfony/emoji": "^7.1|^8.0",
+                "symfony/http-client": "^6.4|^7.0|^8.0",
+                "symfony/intl": "^6.4|^7.0|^8.0",
                 "symfony/translation-contracts": "^2.5|^3.0",
-                "symfony/var-exporter": "^5.4|^6.0|^7.0"
+                "symfony/var-exporter": "^6.4|^7.0|^8.0"
             },
             "type": "library",
             "autoload": {
@@ -4771,7 +6024,7 @@
                 "utf8"
             ],
             "support": {
-                "source": "https://github.com/symfony/string/tree/v6.4.24"
+                "source": "https://github.com/symfony/string/tree/v7.4.4"
             },
             "funding": [
                 {
@@ -4791,20 +6044,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-07-10T08:14:14+00:00"
+            "time": "2026-01-12T10:54:30+00:00"
         },
         {
             "name": "theseer/tokenizer",
-            "version": "1.2.3",
+            "version": "1.3.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/theseer/tokenizer.git",
-                "reference": "737eda637ed5e28c3413cb1ebe8bb52cbf1ca7a2"
+                "reference": "b7489ce515e168639d17feec34b8847c326b0b3c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/737eda637ed5e28c3413cb1ebe8bb52cbf1ca7a2",
-                "reference": "737eda637ed5e28c3413cb1ebe8bb52cbf1ca7a2",
+                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/b7489ce515e168639d17feec34b8847c326b0b3c",
+                "reference": "b7489ce515e168639d17feec34b8847c326b0b3c",
                 "shasum": ""
             },
             "require": {
@@ -4833,7 +6086,7 @@
             "description": "A small library for converting tokenized PHP source code into XML and potentially other formats",
             "support": {
                 "issues": "https://github.com/theseer/tokenizer/issues",
-                "source": "https://github.com/theseer/tokenizer/tree/1.2.3"
+                "source": "https://github.com/theseer/tokenizer/tree/1.3.1"
             },
             "funding": [
                 {
@@ -4841,28 +6094,30 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-03-03T12:36:25+00:00"
+            "time": "2025-11-17T20:03:58+00:00"
         },
         {
             "name": "vimeo/psalm",
-            "version": "5.26.1",
+            "version": "6.14.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/vimeo/psalm.git",
-                "reference": "d747f6500b38ac4f7dfc5edbcae6e4b637d7add0"
+                "reference": "d0b040a91f280f071c1abcb1b77ce3822058725a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/vimeo/psalm/zipball/d747f6500b38ac4f7dfc5edbcae6e4b637d7add0",
-                "reference": "d747f6500b38ac4f7dfc5edbcae6e4b637d7add0",
+                "url": "https://api.github.com/repos/vimeo/psalm/zipball/d0b040a91f280f071c1abcb1b77ce3822058725a",
+                "reference": "d0b040a91f280f071c1abcb1b77ce3822058725a",
                 "shasum": ""
             },
             "require": {
-                "amphp/amp": "^2.4.2",
-                "amphp/byte-stream": "^1.5",
+                "amphp/amp": "^3",
+                "amphp/byte-stream": "^2",
+                "amphp/parallel": "^2.3",
                 "composer-runtime-api": "^2",
                 "composer/semver": "^1.4 || ^2.0 || ^3.0",
                 "composer/xdebug-handler": "^2.0 || ^3.0",
+                "danog/advanced-json-rpc": "^3.1",
                 "dnoegel/php-xdg-base-dir": "^0.1.1",
                 "ext-ctype": "*",
                 "ext-dom": "*",
@@ -4871,27 +6126,26 @@
                 "ext-mbstring": "*",
                 "ext-simplexml": "*",
                 "ext-tokenizer": "*",
-                "felixfbecker/advanced-json-rpc": "^3.1",
-                "felixfbecker/language-server-protocol": "^1.5.2",
+                "felixfbecker/language-server-protocol": "^1.5.3",
                 "fidry/cpu-core-counter": "^0.4.1 || ^0.5.1 || ^1.0.0",
-                "netresearch/jsonmapper": "^1.0 || ^2.0 || ^3.0 || ^4.0",
-                "nikic/php-parser": "^4.17",
-                "php": "^7.4 || ~8.0.0 || ~8.1.0 || ~8.2.0 || ~8.3.0",
-                "sebastian/diff": "^4.0 || ^5.0 || ^6.0",
+                "netresearch/jsonmapper": "^5.0",
+                "nikic/php-parser": "^5.0.0",
+                "php": "~8.1.31 || ~8.2.27 || ~8.3.16 || ~8.4.3 || ~8.5.0",
+                "sebastian/diff": "^4.0 || ^5.0 || ^6.0 || ^7.0",
                 "spatie/array-to-xml": "^2.17.0 || ^3.0",
-                "symfony/console": "^4.1.6 || ^5.0 || ^6.0 || ^7.0",
-                "symfony/filesystem": "^5.4 || ^6.0 || ^7.0"
-            },
-            "conflict": {
-                "nikic/php-parser": "4.17.0"
+                "symfony/console": "^6.0 || ^7.0 || ^8.0",
+                "symfony/filesystem": "~6.3.12 || ~6.4.3 || ^7.0.3 || ^8.0",
+                "symfony/polyfill-php84": "^1.31.0"
             },
             "provide": {
                 "psalm/psalm": "self.version"
             },
             "require-dev": {
-                "amphp/phpunit-util": "^2.0",
+                "amphp/phpunit-util": "^3",
                 "bamarni/composer-bin-plugin": "^1.4",
                 "brianium/paratest": "^6.9",
+                "danog/class-finder": "^0.4.8",
+                "dg/bypass-finals": "^1.5",
                 "ext-curl": "*",
                 "mockery/mockery": "^1.5",
                 "nunomaduro/mock-final-classes": "^1.1",
@@ -4899,10 +6153,10 @@
                 "phpstan/phpdoc-parser": "^1.6",
                 "phpunit/phpunit": "^9.6",
                 "psalm/plugin-mockery": "^1.1",
-                "psalm/plugin-phpunit": "^0.18",
+                "psalm/plugin-phpunit": "^0.19",
                 "slevomat/coding-standard": "^8.4",
                 "squizlabs/php_codesniffer": "^3.6",
-                "symfony/process": "^4.4 || ^5.0 || ^6.0 || ^7.0"
+                "symfony/process": "^6.0 || ^7.0 || ^8.0"
             },
             "suggest": {
                 "ext-curl": "In order to send data to shepherd",
@@ -4913,6 +6167,7 @@
                 "psalm-language-server",
                 "psalm-plugin",
                 "psalm-refactor",
+                "psalm-review",
                 "psalter"
             ],
             "type": "project",
@@ -4922,7 +6177,9 @@
                     "dev-2.x": "2.x-dev",
                     "dev-3.x": "3.x-dev",
                     "dev-4.x": "4.x-dev",
-                    "dev-master": "5.x-dev"
+                    "dev-5.x": "5.x-dev",
+                    "dev-6.x": "6.x-dev",
+                    "dev-master": "7.x-dev"
                 }
             },
             "autoload": {
@@ -4937,6 +6194,10 @@
             "authors": [
                 {
                     "name": "Matthew Brown"
+                },
+                {
+                    "name": "Daniil Gentili",
+                    "email": "daniil@daniil.it"
                 }
             ],
             "description": "A static analysis tool for finding errors in PHP applications",
@@ -4951,7 +6212,7 @@
                 "issues": "https://github.com/vimeo/psalm/issues",
                 "source": "https://github.com/vimeo/psalm"
             },
-            "time": "2024-09-08T18:53:08+00:00"
+            "time": "2025-12-23T15:36:48+00:00"
         },
         {
             "name": "webimpress/coding-standard",
@@ -5074,11 +6335,11 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": "~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0"
+        "php": "~8.2.0 || ~8.3.0 || ~8.4.0 || ~8.5.0"
     },
     "platform-dev": {},
     "platform-overrides": {
-        "php": "8.1.99"
+        "php": "8.2.99"
     },
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.9.0"
 }

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -281,9 +281,6 @@
     <UnusedClass>
       <code><![CDATA[IterableInterface]]></code>
     </UnusedClass>
-  <MethodSignatureMustProvideReturnType>
-    <code><![CDATA[getIterator]]></code>
-  </MethodSignatureMustProvideReturnType>
   </file>
   <file src="src/Storage/IteratorInterface.php">
     <PossiblyUnusedMethod>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="5.26.1@d747f6500b38ac4f7dfc5edbcae6e4b637d7add0">
+<files psalm-version="6.14.3@d0b040a91f280f071c1abcb1b77ce3822058725a">
   <file src="src/Exception/BadMethodCallException.php">
     <UnusedClass>
       <code><![CDATA[BadMethodCallException]]></code>
@@ -75,15 +75,6 @@
     </PossiblyUnusedReturnValue>
   </file>
   <file src="src/Pattern/ObjectCache.php">
-    <MixedArgument>
-      <code><![CDATA[$property]]></code>
-      <code><![CDATA[$property]]></code>
-      <code><![CDATA[$property]]></code>
-      <code><![CDATA[$property]]></code>
-    </MixedArgument>
-    <MixedInferredReturnType>
-      <code><![CDATA[bool]]></code>
-    </MixedInferredReturnType>
     <MixedReturnStatement>
       <code><![CDATA[$this->call('__isset', [$name])]]></code>
     </MixedReturnStatement>
@@ -98,6 +89,13 @@
     </MixedArgument>
   </file>
   <file src="src/Pattern/PatternOptions.php">
+    <InvalidOperand>
+      <code><![CDATA[$dirPermission & 0700]]></code>
+      <code><![CDATA[$filePermission & 0111]]></code>
+      <code><![CDATA[$filePermission & 0600]]></code>
+      <code><![CDATA[$umask & 0700]]></code>
+      <code><![CDATA[$umask &= ~0002]]></code>
+    </InvalidOperand>
     <MixedArgument>
       <code><![CDATA[$array]]></code>
     </MixedArgument>
@@ -118,6 +116,14 @@
       <code><![CDATA[setPublicDir]]></code>
       <code><![CDATA[setUmask]]></code>
     </PossiblyUnusedMethod>
+  </file>
+  <file src="src/Psr/SimpleCache/SimpleCacheDecorator.php">
+    <InvalidReturnStatement>
+      <code><![CDATA[$results]]></code>
+    </InvalidReturnStatement>
+    <InvalidReturnType>
+      <code><![CDATA[array]]></code>
+    </InvalidReturnType>
   </file>
   <file src="src/Service/StorageAdapterFactory.php">
     <InvalidArgument>
@@ -204,6 +210,9 @@
     <MixedArgument>
       <code><![CDATA[$args['key']]]></code>
       <code><![CDATA[$handle]]></code>
+      <code><![CDATA[$key]]></code>
+      <code><![CDATA[$key]]></code>
+      <code><![CDATA[$key]]></code>
     </MixedArgument>
     <MoreSpecificImplementedParamType>
       <code><![CDATA[$options]]></code>
@@ -272,6 +281,9 @@
     <UnusedClass>
       <code><![CDATA[IterableInterface]]></code>
     </UnusedClass>
+  <MethodSignatureMustProvideReturnType>
+    <code><![CDATA[getIterator]]></code>
+  </MethodSignatureMustProvideReturnType>
   </file>
   <file src="src/Storage/IteratorInterface.php">
     <PossiblyUnusedMethod>
@@ -454,43 +466,18 @@
     </UnusedClass>
   </file>
   <file src="test/Storage/Adapter/AbstractAdapterTest.php">
-    <DeprecatedMethod>
-      <code><![CDATA[disableArgumentCloning]]></code>
-      <code><![CDATA[getMockForAbstractClass]]></code>
-      <code><![CDATA[returnValue]]></code>
-      <code><![CDATA[returnValue]]></code>
-    </DeprecatedMethod>
-    <MixedArgument>
-      <code><![CDATA[$success]]></code>
-    </MixedArgument>
     <MixedMethodCall>
       <code><![CDATA[getResult]]></code>
     </MixedMethodCall>
-    <PossiblyUndefinedVariable>
-      <code><![CDATA[$success]]></code>
-    </PossiblyUndefinedVariable>
     <PossiblyUnusedMethod>
       <code><![CDATA[simpleEventHandlingMethodDefinitions]]></code>
     </PossiblyUnusedMethod>
   </file>
-  <file src="test/Storage/Adapter/AbstractMetadataCapableAdapterTest.php">
-    <DeprecatedMethod>
-      <code><![CDATA[disableArgumentCloning]]></code>
-      <code><![CDATA[getMockForAbstractClass]]></code>
-    </DeprecatedMethod>
-  </file>
-  <file src="test/Storage/Adapter/AdapterOptionsTest.php">
-    <DeprecatedMethod>
-      <code><![CDATA[getMockForAbstractClass]]></code>
-    </DeprecatedMethod>
-  </file>
   <file src="test/Storage/Adapter/TestAsset/AdapterWithStorageAndEventsCapableInterface.php">
-    <MissingReturnType>
+    <PossiblyUnusedMethod>
       <code><![CDATA[addPlugin]]></code>
-    </MissingReturnType>
-    <UnusedClass>
-      <code><![CDATA[AdapterWithStorageAndEventsCapableInterface]]></code>
-    </UnusedClass>
+      <code><![CDATA[hasPlugin]]></code>
+    </PossiblyUnusedMethod>
   </file>
   <file src="test/Storage/AdapterPluginManagerTest.php">
     <MissingReturnType>
@@ -540,9 +527,6 @@
       <code><![CDATA[$this->adapter->getEventManager()]]></code>
       <code><![CDATA[$this->adapter->getEventManager()]]></code>
     </ArgumentTypeCoercion>
-    <DeprecatedMethod>
-      <code><![CDATA[getMockForAbstractClass]]></code>
-    </DeprecatedMethod>
     <InvalidArgument>
       <code><![CDATA[$cb]]></code>
       <code><![CDATA[$cb]]></code>

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -9,6 +9,7 @@
         findUnusedPsalmSuppress="true"
         findUnusedBaselineEntry="true"
         findUnusedCode="true"
+        ensureOverrideAttribute="false"
 >
     <projectFiles>
         <directory name="src"/>

--- a/src/Exception/BadMethodCallException.php
+++ b/src/Exception/BadMethodCallException.php
@@ -2,6 +2,7 @@
 
 namespace Laminas\Cache\Exception;
 
+/** @final */
 class BadMethodCallException extends \BadMethodCallException implements
     ExceptionInterface
 {

--- a/src/Exception/ExtensionNotLoadedException.php
+++ b/src/Exception/ExtensionNotLoadedException.php
@@ -2,6 +2,7 @@
 
 namespace Laminas\Cache\Exception;
 
+/** @final */
 class ExtensionNotLoadedException extends RuntimeException
 {
 }

--- a/src/Exception/InvalidArgumentException.php
+++ b/src/Exception/InvalidArgumentException.php
@@ -2,6 +2,7 @@
 
 namespace Laminas\Cache\Exception;
 
+/** @final */
 class InvalidArgumentException extends \InvalidArgumentException implements
     ExceptionInterface
 {

--- a/src/Exception/LogicException.php
+++ b/src/Exception/LogicException.php
@@ -2,6 +2,7 @@
 
 namespace Laminas\Cache\Exception;
 
+/** @final */
 class LogicException extends \LogicException implements ExceptionInterface
 {
 }

--- a/src/Exception/MissingDependencyException.php
+++ b/src/Exception/MissingDependencyException.php
@@ -2,6 +2,7 @@
 
 namespace Laminas\Cache\Exception;
 
+/** @final */
 class MissingDependencyException extends RuntimeException
 {
 }

--- a/src/Exception/OutOfSpaceException.php
+++ b/src/Exception/OutOfSpaceException.php
@@ -4,6 +4,7 @@ namespace Laminas\Cache\Exception;
 
 use OverflowException;
 
+/** @final */
 class OutOfSpaceException extends OverflowException implements ExceptionInterface
 {
 }

--- a/src/Exception/UnexpectedValueException.php
+++ b/src/Exception/UnexpectedValueException.php
@@ -2,6 +2,7 @@
 
 namespace Laminas\Cache\Exception;
 
+/** @final */
 class UnexpectedValueException extends \UnexpectedValueException implements
     ExceptionInterface
 {

--- a/src/Exception/UnsupportedMethodCallException.php
+++ b/src/Exception/UnsupportedMethodCallException.php
@@ -4,6 +4,7 @@ namespace Laminas\Cache\Exception;
 
 use BadMethodCallException;
 
+/** @final */
 class UnsupportedMethodCallException extends BadMethodCallException implements
     ExceptionInterface
 {

--- a/src/Pattern/CaptureCache.php
+++ b/src/Pattern/CaptureCache.php
@@ -7,6 +7,7 @@ use Laminas\Cache\Exception;
 use Laminas\Stdlib\ErrorHandler;
 
 use function array_unshift;
+use function assert;
 use function basename;
 use function chmod;
 use function decoct;
@@ -14,6 +15,7 @@ use function dirname;
 use function file_exists;
 use function file_get_contents;
 use function file_put_contents;
+use function is_string;
 use function mkdir;
 use function ob_implicit_flush;
 use function ob_start;
@@ -176,7 +178,8 @@ final class CaptureCache extends AbstractPattern
             GlobIterator::CURRENT_AS_SELF | GlobIterator::SKIP_DOTS | GlobIterator::UNIX_PATHS
         );
         foreach ($it as $pathname => $entry) {
-            if ($entry->isFile()) {
+            assert(is_string($pathname));
+            if ($entry?->isFile() === true) {
                 unlink($pathname);
             }
         }

--- a/src/Pattern/ObjectCache.php
+++ b/src/Pattern/ObjectCache.php
@@ -13,6 +13,7 @@ use function array_unshift;
 use function assert;
 use function func_get_args;
 use function in_array;
+use function is_string;
 use function method_exists;
 use function property_exists;
 use function sprintf;
@@ -67,6 +68,7 @@ final class ObjectCache extends AbstractStorageCapablePattern implements Stringa
             case '__set':
                 $property = array_shift($args);
                 $value    = array_shift($args);
+                assert(is_string($property));
 
                 $object->{$property} = $value;
 
@@ -95,6 +97,7 @@ final class ObjectCache extends AbstractStorageCapablePattern implements Stringa
 
             case '__get':
                 $property = array_shift($args);
+                assert(is_string($property));
 
                 if (
                     ! $options->getObjectCacheMagicProperties()
@@ -110,7 +113,7 @@ final class ObjectCache extends AbstractStorageCapablePattern implements Stringa
 
             case '__isset':
                 $property = array_shift($args);
-
+                assert(is_string($property));
                 if (
                     ! $options->getObjectCacheMagicProperties()
                     || property_exists($object, $property)
@@ -124,6 +127,7 @@ final class ObjectCache extends AbstractStorageCapablePattern implements Stringa
 
             case '__unset':
                 $property = array_shift($args);
+                assert(is_string($property));
 
                 unset($object->{$property});
 

--- a/src/Pattern/PatternOptions.php
+++ b/src/Pattern/PatternOptions.php
@@ -10,6 +10,7 @@ use function array_intersect;
 use function array_map;
 use function array_unique;
 use function array_values;
+use function assert;
 use function gettype;
 use function is_dir;
 use function is_object;
@@ -483,7 +484,9 @@ final class PatternOptions extends AbstractOptions
             );
         }
 
-        $this->publicDir = rtrim(realpath($publicDir), DIRECTORY_SEPARATOR);
+        $path = realpath($publicDir);
+        assert(is_string($path));
+        $this->publicDir = rtrim($path, DIRECTORY_SEPARATOR);
         return $this;
     }
 

--- a/src/Psr/CacheItemPool/CacheException.php
+++ b/src/Psr/CacheItemPool/CacheException.php
@@ -5,6 +5,7 @@ namespace Laminas\Cache\Psr\CacheItemPool;
 use Psr\Cache\CacheException as CacheExceptionInterface;
 use RuntimeException;
 
+/** @final */
 class CacheException extends RuntimeException implements CacheExceptionInterface
 {
 }

--- a/src/Psr/CacheItemPool/InvalidArgumentException.php
+++ b/src/Psr/CacheItemPool/InvalidArgumentException.php
@@ -6,6 +6,7 @@ use Psr\Cache\InvalidArgumentException as InvalidArgumentExceptionInterface;
 
 use function sprintf;
 
+/** @final */
 class InvalidArgumentException extends \InvalidArgumentException implements InvalidArgumentExceptionInterface
 {
     public static function maximumKeyLengthExceeded(string $key, int $maximumKeyLength): self

--- a/src/Psr/SimpleCache/SimpleCacheDecorator.php
+++ b/src/Psr/SimpleCache/SimpleCacheDecorator.php
@@ -365,7 +365,7 @@ final class SimpleCacheDecorator implements SimpleCacheInterface
      */
     private function memoizeTtlCapabilities(Capabilities $capabilities): void
     {
-        $this->providesPerItemTtl = 0 < $capabilities->ttlSupported;
+        $this->providesPerItemTtl = $capabilities->ttlSupported;
     }
 
     /**

--- a/src/Psr/SimpleCache/SimpleCacheException.php
+++ b/src/Psr/SimpleCache/SimpleCacheException.php
@@ -5,6 +5,7 @@ namespace Laminas\Cache\Psr\SimpleCache;
 use Psr\SimpleCache\CacheException as PsrCacheException;
 use RuntimeException;
 
+/** @final */
 class SimpleCacheException extends RuntimeException implements PsrCacheException
 {
 }

--- a/src/Psr/SimpleCache/SimpleCacheInvalidArgumentException.php
+++ b/src/Psr/SimpleCache/SimpleCacheInvalidArgumentException.php
@@ -7,6 +7,7 @@ use Psr\SimpleCache\InvalidArgumentException as PsrInvalidArgumentException;
 
 use function sprintf;
 
+/** @final */
 class SimpleCacheInvalidArgumentException extends InvalidArgumentException implements PsrInvalidArgumentException
 {
     public static function maximumKeyLengthExceeded(string $key, int $maximumKeyLength): self

--- a/src/Service/StorageCacheAbstractServiceFactory.php
+++ b/src/Service/StorageCacheAbstractServiceFactory.php
@@ -11,6 +11,8 @@ use function is_array;
 
 /**
  * Storage cache factory for multiple caches.
+ *
+ * @final
  */
 class StorageCacheAbstractServiceFactory implements AbstractFactoryInterface
 {

--- a/src/Storage/Adapter/AbstractAdapter.php
+++ b/src/Storage/Adapter/AbstractAdapter.php
@@ -255,7 +255,7 @@ abstract class AbstractAdapter implements StorageInterface, PluginAwareInterface
     {
         $registry = $this->getPluginRegistry();
 
-        return $registry->contains($plugin);
+        return $registry->offsetExists($plugin);
     }
 
     /**
@@ -264,7 +264,7 @@ abstract class AbstractAdapter implements StorageInterface, PluginAwareInterface
     public function addPlugin(Plugin\PluginInterface $plugin, int $priority = 1): StorageInterface&PluginAwareInterface
     {
         $registry = $this->getPluginRegistry();
-        if ($registry->contains($plugin)) {
+        if ($registry->offsetExists($plugin)) {
             throw new Exception\LogicException(sprintf(
                 'Plugin of type "%s" already registered',
                 $plugin::class
@@ -272,7 +272,7 @@ abstract class AbstractAdapter implements StorageInterface, PluginAwareInterface
         }
 
         $plugin->attach($this->getEventManager(), $priority);
-        $registry->attach($plugin);
+        $registry->offsetSet($plugin);
 
         return $this;
     }
@@ -283,9 +283,9 @@ abstract class AbstractAdapter implements StorageInterface, PluginAwareInterface
     public function removePlugin(Plugin\PluginInterface $plugin): self
     {
         $registry = $this->getPluginRegistry();
-        if ($registry->contains($plugin)) {
+        if ($registry->offsetExists($plugin)) {
             $plugin->detach($this->getEventManager());
-            $registry->detach($plugin);
+            $registry->offsetUnset($plugin);
         }
 
         return $this;

--- a/src/Storage/Adapter/AdapterOptions.php
+++ b/src/Storage/Adapter/AdapterOptions.php
@@ -170,6 +170,8 @@ class AdapterOptions extends AbstractOptions
 
     /**
      * Set time to live.
+     *
+     * @param int|float|numeric-string $ttl
      */
     public function setTtl(int|float|string $ttl): self
     {

--- a/src/Storage/Adapter/AdapterOptions.php
+++ b/src/Storage/Adapter/AdapterOptions.php
@@ -15,6 +15,7 @@ use Webmozart\Assert\Assert;
 use function array_change_key_case;
 use function array_reverse;
 use function array_shift;
+use function assert;
 use function is_array;
 use function is_int;
 use function iterator_to_array;
@@ -169,8 +170,6 @@ class AdapterOptions extends AbstractOptions
 
     /**
      * Set time to live.
-     *
-     * @param numeric $ttl
      */
     public function setTtl(int|float|string $ttl): self
     {
@@ -227,7 +226,6 @@ class AdapterOptions extends AbstractOptions
     /**
      * Validates and normalize a TTL.
      *
-     * @param numeric $ttl
      * @return non-negative-int|float $ttl
      * @throws Exception\InvalidArgumentException
      */
@@ -265,7 +263,8 @@ class AdapterOptions extends AbstractOptions
             if ($key === '__strictMode__' || $key === '__prioritizedProperties__') {
                 continue;
             }
-            $normalizedKey         = preg_replace_callback('/([A-Z])/', $transform, $key);
+            $normalizedKey = preg_replace_callback('/([A-Z])/', $transform, $key);
+            assert($normalizedKey !== null);
             $array[$normalizedKey] = $value;
         }
         Assert::isMap($array);

--- a/src/Storage/ExceptionEvent.php
+++ b/src/Storage/ExceptionEvent.php
@@ -6,6 +6,7 @@ use ArrayObject;
 use Laminas\Cache\Storage\Adapter\AdapterOptions;
 use Throwable;
 
+/** @final */
 class ExceptionEvent extends PostEvent
 {
     /**

--- a/src/Storage/IterableInterface.php
+++ b/src/Storage/IterableInterface.php
@@ -3,13 +3,19 @@
 namespace Laminas\Cache\Storage;
 
 use IteratorAggregate;
+use Traversable;
 
 /**
- * @method IteratorInterface getIterator() Get the storage iterator
  * @template-covariant TKey
  * @template-covariant TValue
  * @template-extends IteratorAggregate<TKey, TValue>
  */
 interface IterableInterface extends IteratorAggregate
 {
+    /**
+     * Get the storage iterator
+     *
+     * @return Traversable<TKey, TValue>|TValue[]
+     */
+    public function getIterator();
 }

--- a/src/Storage/IterableInterface.php
+++ b/src/Storage/IterableInterface.php
@@ -3,7 +3,6 @@
 namespace Laminas\Cache\Storage;
 
 use IteratorAggregate;
-use Traversable;
 
 /**
  * @template-covariant TKey
@@ -12,10 +11,4 @@ use Traversable;
  */
 interface IterableInterface extends IteratorAggregate
 {
-    /**
-     * Get the storage iterator
-     *
-     * @return Traversable<TKey, TValue>|TValue[]
-     */
-    public function getIterator();
 }

--- a/src/Storage/Plugin/PluginOptions.php
+++ b/src/Storage/Plugin/PluginOptions.php
@@ -13,6 +13,7 @@ use function is_string;
 
 /**
  * @template-extends AbstractOptions<mixed>
+ * @final
  */
 class PluginOptions extends AbstractOptions
 {

--- a/src/Storage/PluginManager.php
+++ b/src/Storage/PluginManager.php
@@ -11,6 +11,7 @@ use Psr\Container\ContainerInterface;
 use Webmozart\Assert\Assert;
 
 use function array_replace_recursive;
+use function assert;
 
 /**
  * Plugin manager implementation for cache plugins
@@ -68,6 +69,7 @@ final class PluginManager extends AbstractSingleInstancePluginManager
     {
         $options ??= [];
         $plugin    = parent::build($name);
+        assert($plugin instanceof PluginInterface);
         if ($options !== []) {
             Assert::isMap($options);
             $plugin->setOptions(new PluginOptions($options));

--- a/test/Pattern/AbstractCommonPatternTestCase.php
+++ b/test/Pattern/AbstractCommonPatternTestCase.php
@@ -6,12 +6,12 @@ namespace LaminasTest\Cache\Pattern;
 
 use Laminas\Cache\Pattern\PatternInterface;
 use Laminas\Cache\Pattern\PatternOptions;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 
-/**
- * @group      Laminas_Cache
- * @covers Laminas\Cache\Pattern\PatternOptions<extended>
- */
+#[Group('Laminas_Cache')]
+#[CoversClass(PatternOptions::class)]
 abstract class AbstractCommonPatternTestCase extends TestCase
 {
     protected PatternInterface $pattern;

--- a/test/Pattern/CallbackCacheTest.php
+++ b/test/Pattern/CallbackCacheTest.php
@@ -8,6 +8,7 @@ use Laminas\Cache\Pattern\CallbackCache;
 use Laminas\Cache\Storage\StorageInterface;
 use LaminasTest\Cache\Pattern\TestAsset\FailableCallback;
 use LaminasTest\Cache\Pattern\TestAsset\TestCallbackCache;
+use PHPUnit\Framework\Attributes\Group;
 
 use function func_get_args;
 use function implode;
@@ -25,10 +26,10 @@ function bar(): string
 }
 
 /**
- * @group      Laminas_Cache
  * @template-extends AbstractCommonStoragePatternTestCase<CallbackCache>
  */
-class CallbackCacheTest extends AbstractCommonStoragePatternTestCase
+#[Group('Laminas_Cache')]
+final class CallbackCacheTest extends AbstractCommonStoragePatternTestCase
 {
     protected function setUp(): void
     {
@@ -81,13 +82,13 @@ class CallbackCacheTest extends AbstractCommonStoragePatternTestCase
         $generatedKey = $this->pattern->generateKey($callback, $args);
 
         $this->storage
-        ->expects(self::once())
+        ->expects($this->once())
         ->method('getItem')
         ->with($generatedKey, null)
         ->willReturn(null);
 
         $this->storage
-        ->expects(self::once())
+        ->expects($this->once())
         ->method('setItem')
         ->with($generatedKey, self::anything())
         ->willReturn(true);
@@ -169,15 +170,13 @@ class CallbackCacheTest extends AbstractCommonStoragePatternTestCase
         }
     }
 
-    /**
-     * @group 4629
-     */
+    #[Group('4629')]
     public function testCallCanReturnCachedNullValues(): void
     {
         $callback = new FailableCallback();
         $key      = $this->pattern->generateKey($callback, []);
         $this->storage
-        ->expects(self::once())
+        ->expects($this->once())
         ->method('getItem')
         ->with($key, null)
         ->willReturnCallback(function (string $key, ?bool &$success = null): array {

--- a/test/Pattern/CaptureCacheTest.php
+++ b/test/Pattern/CaptureCacheTest.php
@@ -7,6 +7,8 @@ namespace LaminasTest\Cache\Pattern;
 use DirectoryIterator;
 use Laminas\Cache;
 use Laminas\Cache\Exception\LogicException;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
 
 use function error_get_last;
 use function file_exists;
@@ -20,11 +22,9 @@ use function unlink;
 
 use const DIRECTORY_SEPARATOR;
 
-/**
- * @group      Laminas_Cache
- * @covers \Laminas\Cache\Pattern\CaptureCache<extended>
- */
-class CaptureCacheTest extends AbstractCommonPatternTestCase
+#[Group('Laminas_Cache')]
+#[CoversClass(Cache\Pattern\CaptureCache::class)]
+final class CaptureCacheTest extends AbstractCommonPatternTestCase
 {
     /** @var string */
     protected $tmpCacheDir;
@@ -40,17 +40,19 @@ class CaptureCacheTest extends AbstractCommonPatternTestCase
         $this->bufferedServerSuperGlobal = $_SERVER;
         $this->umask                     = umask();
 
-        $this->tmpCacheDir = @tempnam(sys_get_temp_dir(), 'laminas_cache_test_');
-        if ($this->tmpCacheDir === false) {
+        $tmpCacheDir = @tempnam(sys_get_temp_dir(), 'laminas_cache_test_');
+        if ($tmpCacheDir === false) {
             $err = error_get_last();
             self::fail("Can't create temporary cache directory-file: {$err['message']}");
-        } elseif (! @unlink($this->tmpCacheDir)) {
+        } elseif (! @unlink($tmpCacheDir)) {
             $err = error_get_last();
             self::fail("Can't remove temporary cache directory-file: {$err['message']}");
-        } elseif (! @mkdir($this->tmpCacheDir, 0777)) {
+        } elseif (! @mkdir($tmpCacheDir, 0777)) {
             $err = error_get_last();
             self::fail("Can't create temporary cache directory: {$err['message']}");
         }
+
+        $this->tmpCacheDir = $tmpCacheDir;
 
         $this->options = new Cache\Pattern\PatternOptions([
             'public_dir' => $this->tmpCacheDir,

--- a/test/Pattern/ObjectCacheTest.php
+++ b/test/Pattern/ObjectCacheTest.php
@@ -8,6 +8,7 @@ use Laminas\Cache;
 use Laminas\Cache\Pattern\ObjectCache;
 use Laminas\Cache\Storage\StorageInterface;
 use LaminasTest\Cache\Pattern\TestAsset\TestObjectCache;
+use PHPUnit\Framework\Attributes\Group;
 
 use function implode;
 use function ob_end_clean;
@@ -16,10 +17,10 @@ use function ob_implicit_flush;
 use function ob_start;
 
 /**
- * @group      Laminas_Cache
  * @template-extends AbstractCommonStoragePatternTestCase<ObjectCache>
  */
-class ObjectCacheTest extends AbstractCommonStoragePatternTestCase
+#[Group('Laminas_Cache')]
+final class ObjectCacheTest extends AbstractCommonStoragePatternTestCase
 {
     protected function setUp(): void
     {
@@ -70,13 +71,13 @@ class ObjectCacheTest extends AbstractCommonStoragePatternTestCase
         $generatedKey = $this->pattern->generateKey('emptyMethod', $args);
 
         $this->storage
-            ->expects(self::once())
+            ->expects($this->once())
             ->method('getItem')
             ->with($generatedKey, null)
             ->willReturn(null);
 
         $this->storage
-            ->expects(self::once())
+            ->expects($this->once())
             ->method('setItem')
             ->with($generatedKey, self::anything())
             ->willReturn(true);
@@ -86,12 +87,14 @@ class ObjectCacheTest extends AbstractCommonStoragePatternTestCase
 
     public function testSetProperty(): void
     {
+        /** @psalm-suppress UndefinedMagicPropertyAssignment */
         $this->pattern->property = 'testSetProperty';
         self::assertEquals('testSetProperty', $this->options->getObject()->property);
     }
 
     public function testGetProperty(): void
     {
+        /** @psalm-suppress UndefinedMagicPropertyFetch */
         self::assertEquals($this->options->getObject()->property, $this->pattern->property);
     }
 
@@ -103,13 +106,12 @@ class ObjectCacheTest extends AbstractCommonStoragePatternTestCase
 
     public function testUnsetProperty(): void
     {
+        /** @psalm-suppress UndefinedMagicPropertyFetch */
         unset($this->pattern->property);
         self::assertFalse(isset($this->pattern->property));
     }
 
-    /**
-     * @group 7039
-     */
+    #[Group('7039')]
     public function testEmptyObjectKeys(): void
     {
         $this->options->setObjectKey('0');

--- a/test/Pattern/OutputCacheTest.php
+++ b/test/Pattern/OutputCacheTest.php
@@ -6,6 +6,8 @@ namespace LaminasTest\Cache\Pattern;
 
 use Laminas\Cache\Pattern\OutputCache;
 use Laminas\Cache\Storage\StorageInterface;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
 
 use function ob_end_clean;
 use function ob_get_clean;
@@ -13,11 +15,11 @@ use function ob_get_level;
 use function ob_start;
 
 /**
- * @group      Laminas_Cache
- * @covers \Laminas\Cache\Pattern\OutputCache<extended>
  * @template-extends AbstractCommonStoragePatternTestCase<OutputCache>
  */
-class OutputCacheTest extends AbstractCommonStoragePatternTestCase
+#[Group('Laminas_Cache')]
+#[CoversClass(OutputCache::class)]
+final class OutputCacheTest extends AbstractCommonStoragePatternTestCase
 {
     /**
      * Nesting level of output buffering used to restore on tearDown(): void
@@ -69,7 +71,7 @@ class OutputCacheTest extends AbstractCommonStoragePatternTestCase
         $key    = 'testStartEndCacheMiss';
 
         $this->storage
-            ->expects(self::once())
+            ->expects($this->once())
             ->method('setItem')
             ->with($key, $output)
             ->willReturn(true);
@@ -93,7 +95,7 @@ class OutputCacheTest extends AbstractCommonStoragePatternTestCase
             ->method('setItem');
 
         $this->storage
-            ->expects(self::once())
+            ->expects($this->once())
             ->method('getItem')
             ->with($key, null)
             ->willReturnCallback(function (string $key, ?bool &$success = null) use ($output): string {

--- a/test/Psr/CacheItemPool/CacheItemPoolDecoratorTest.php
+++ b/test/Psr/CacheItemPool/CacheItemPoolDecoratorTest.php
@@ -18,6 +18,7 @@ use Laminas\Cache\Storage\FlushableInterface;
 use Laminas\Cache\Storage\StorageInterface;
 use LaminasTest\Cache\Psr\CacheItemPool\TestAsset\FlushableStorageAdapterInterface;
 use LaminasTest\Cache\Psr\TestAsset\FlushableNamespaceStorageInterface;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Cache\CacheItemInterface;
@@ -112,7 +113,7 @@ final class CacheItemPoolDecoratorTest extends TestCase
         ]);
 
         $storage
-            ->expects(self::once())
+            ->expects($this->once())
             ->method('getCapabilities')
             ->willReturn($capabilities);
 
@@ -131,7 +132,7 @@ final class CacheItemPoolDecoratorTest extends TestCase
         $storage = $this->storage;
 
         $storage
-            ->expects(self::once())
+            ->expects($this->once())
             ->method('getItem')
             ->with('foo')
             ->willReturnOnConsecutiveCalls(null);
@@ -148,9 +149,7 @@ final class CacheItemPoolDecoratorTest extends TestCase
         self::assertEquals('bar', $item->get());
     }
 
-    /**
-     * @dataProvider invalidKeyProvider
-     */
+    #[DataProvider('invalidKeyProvider')]
     public function testGetItemInvalidKeyThrowsException(mixed $key)
     {
         $this->expectException(InvalidArgumentException::class);
@@ -162,7 +161,7 @@ final class CacheItemPoolDecoratorTest extends TestCase
     {
         $storage = $this->storage;
         $storage
-            ->expects(self::once())
+            ->expects($this->once())
             ->method('getItem')
             ->willThrowException(new Exception\RuntimeException());
 
@@ -176,7 +175,7 @@ final class CacheItemPoolDecoratorTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
         $storage = $this->storage;
         $storage
-            ->expects(self::once())
+            ->expects($this->once())
             ->method('getItem')
             ->willThrowException(new Exception\InvalidArgumentException());
         $this->getAdapter($storage)->getItem('foo');
@@ -187,7 +186,7 @@ final class CacheItemPoolDecoratorTest extends TestCase
         $keys    = ['foo', 'bar'];
         $storage = $this->storage;
         $storage
-            ->expects(self::once())
+            ->expects($this->once())
             ->method('getItems')
             ->with($keys)
             ->willReturn([]);
@@ -209,7 +208,7 @@ final class CacheItemPoolDecoratorTest extends TestCase
         $keys    = ['foo', 'bar'];
         $storage = $this->storage;
         $storage
-            ->expects(self::once())
+            ->expects($this->once())
             ->method('getItems')
             ->with($keys)
             ->willReturn([]);
@@ -234,7 +233,7 @@ final class CacheItemPoolDecoratorTest extends TestCase
         $storage = $this->storage;
 
         $storage
-            ->expects(self::once())
+            ->expects($this->once())
             ->method('getItems')
             ->with($keys)
             ->willReturn(['bar' => 'value']);
@@ -261,7 +260,7 @@ final class CacheItemPoolDecoratorTest extends TestCase
         $keys    = ['foo', 'bar'];
         $storage = $this->storage;
         $storage
-            ->expects(self::once())
+            ->expects($this->once())
             ->method('getItems')
             ->with($keys)
             ->willThrowException(new Exception\RuntimeException());
@@ -278,7 +277,7 @@ final class CacheItemPoolDecoratorTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
         $storage = $this->storage;
         $storage
-            ->expects(self::once())
+            ->expects($this->once())
             ->method('getItems')
             ->willThrowException(new Exception\InvalidArgumentException());
         $this->getAdapter($storage)->getItems(['foo', 'bar']);
@@ -288,19 +287,19 @@ final class CacheItemPoolDecoratorTest extends TestCase
     {
         $storage = $this->storage;
         $storage
-            ->expects(self::once())
+            ->expects($this->once())
             ->method('getItem')
             ->with('foo')
             ->wilLReturn(null);
 
         $storage
-            ->expects(self::once())
+            ->expects($this->once())
             ->method('getItems')
             ->with(['foo'])
             ->willReturn(['foo' => 'bar']);
 
         $storage
-            ->expects(self::once())
+            ->expects($this->once())
             ->method('setItems')
             ->with(['foo' => 'bar'])
             ->willReturn(['foo' => true]);
@@ -320,7 +319,7 @@ final class CacheItemPoolDecoratorTest extends TestCase
         $adapter = $this->getAdapter($storage);
 
         $storage
-            ->expects(self::once())
+            ->expects($this->once())
             ->method('getItem')
             ->with('foo')
             ->willReturn(null);
@@ -344,13 +343,13 @@ final class CacheItemPoolDecoratorTest extends TestCase
             ->willReturnSelf();
 
         $storage
-            ->expects(self::once())
+            ->expects($this->once())
             ->method('setItems')
             ->with(['foo' => 'bar'])
             ->willReturn(['foo' => true]);
 
         $storage
-            ->expects(self::once())
+            ->expects($this->once())
             ->method('getItems')
             ->with(['foo'])
             ->willReturn(['foo' => 'bar']);
@@ -379,7 +378,7 @@ final class CacheItemPoolDecoratorTest extends TestCase
             ->willReturnOnConsecutiveCalls(null, 'bar');
 
         $storage
-            ->expects(self::once())
+            ->expects($this->once())
             ->method('setItems')
             ->with(['foo' => 'bar'])
             ->willReturn(['foo' => true]);
@@ -411,7 +410,7 @@ final class CacheItemPoolDecoratorTest extends TestCase
     {
         $storage = $this->storage;
         $storage
-            ->expects(self::once())
+            ->expects($this->once())
             ->method('setItems')
             ->willThrowException(new Exception\RuntimeException());
         $adapter = $this->getAdapter($storage);
@@ -424,7 +423,7 @@ final class CacheItemPoolDecoratorTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
         $storage = $this->storage;
         $storage
-            ->expects(self::once())
+            ->expects($this->once())
             ->method('setItems')
             ->willThrowException(new Exception\InvalidArgumentException());
         $adapter = $this->getAdapter($storage);
@@ -436,19 +435,19 @@ final class CacheItemPoolDecoratorTest extends TestCase
     {
         $storage = $this->storage;
         $storage
-            ->expects(self::once())
+            ->expects($this->once())
             ->method('getItem')
             ->with('foo')
             ->willReturn(null);
 
         $storage
-            ->expects(self::once())
+            ->expects($this->once())
             ->method('setItems')
             ->with(['foo' => 'bar'])
             ->willReturn(['foo' => true]);
 
         $storage
-            ->expects(self::once())
+            ->expects($this->once())
             ->method('hasItem')
             ->with('foo')
             ->willReturn(true);
@@ -464,7 +463,7 @@ final class CacheItemPoolDecoratorTest extends TestCase
     {
         $storage = $this->storage;
         $storage
-            ->expects(self::once())
+            ->expects($this->once())
             ->method('hasItem')
             ->with('foo')
             ->willReturn(false);
@@ -477,7 +476,7 @@ final class CacheItemPoolDecoratorTest extends TestCase
         $storage = $this->storage;
 
         $storage
-            ->expects(self::once())
+            ->expects($this->once())
             ->method('getItem')
             ->with('foo')
             ->willReturn(null);
@@ -494,13 +493,13 @@ final class CacheItemPoolDecoratorTest extends TestCase
     {
         $storage = $this->storage;
         $storage
-            ->expects(self::once())
+            ->expects($this->once())
             ->method('getItem')
             ->with('foo')
             ->willReturn(null);
 
         $storage
-            ->expects(self::once())
+            ->expects($this->once())
             ->method('hasItem')
             ->with('foo')
             ->willReturn(false);
@@ -515,9 +514,7 @@ final class CacheItemPoolDecoratorTest extends TestCase
         self::assertFalse($adapter->hasItem('foo'));
     }
 
-    /**
-     * @dataProvider invalidKeyProvider
-     */
+    #[DataProvider('invalidKeyProvider')]
     public function testHasItemInvalidKeyThrowsException(mixed $key)
     {
         $this->expectException(InvalidArgumentException::class);
@@ -529,7 +526,7 @@ final class CacheItemPoolDecoratorTest extends TestCase
     {
         $storage = $this->storage;
         $storage
-            ->expects(self::once())
+            ->expects($this->once())
             ->method('hasItem')
             ->willThrowException(new Exception\RuntimeException());
         self::assertFalse($this->getAdapter($storage)->hasItem('foo'));
@@ -540,7 +537,7 @@ final class CacheItemPoolDecoratorTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
         $storage = $this->storage;
         $storage
-            ->expects(self::once())
+            ->expects($this->once())
             ->method('hasItem')
             ->willThrowException(new Exception\InvalidArgumentException());
         $this->getAdapter($storage)->hasItem('foo');
@@ -550,19 +547,19 @@ final class CacheItemPoolDecoratorTest extends TestCase
     {
         $storage = $this->storage;
         $storage
-            ->expects(self::once())
+            ->expects($this->once())
             ->method('setItems')
             ->with(['foo' => 'bar'])
             ->willReturn(['foo' => true]);
 
         $this->options
-            ->expects(self::once())
+            ->expects($this->once())
             ->method('getNamespace')
             ->willReturn('laminascache');
 
         $adapter = $this->getAdapter($storage);
         $storage
-            ->expects(self::once())
+            ->expects($this->once())
             ->method('clearByNamespace')
             ->with('laminascache')
             ->willReturn(true);
@@ -578,12 +575,12 @@ final class CacheItemPoolDecoratorTest extends TestCase
         $storage = $this->createMockedStorage(new AdapterOptions(['namespace' => '']));
         $adapter = $this->getAdapter($storage);
         $storage
-            ->expects(self::once())
+            ->expects($this->once())
             ->method('flush')
             ->willReturn(true);
 
         $storage
-            ->expects(self::once())
+            ->expects($this->once())
             ->method('setItems')
             ->with(['foo' => 'bar'])
             ->willReturn(['foo' => true]);
@@ -598,7 +595,7 @@ final class CacheItemPoolDecoratorTest extends TestCase
     {
         $storage = $this->createMockedStorage(new AdapterOptions(['namespace' => '']));
         $storage
-            ->expects(self::once())
+            ->expects($this->once())
             ->method('flush')
             ->willReturn(true);
 
@@ -611,19 +608,19 @@ final class CacheItemPoolDecoratorTest extends TestCase
         $adapter = $this->getAdapter($storage);
 
         $storage
-            ->expects(self::once())
+            ->expects($this->once())
             ->method('hasItem')
             ->willReturn(false);
 
         $this->options
-            ->expects(self::once())
+            ->expects($this->once())
             ->method('getNamespace')
             ->willReturn('bar');
 
         $item = $adapter->getItem('foo');
         $adapter->saveDeferred($item);
         $this->storage
-            ->expects(self::once())
+            ->expects($this->once())
             ->method('clearByNamespace')
             ->with('bar')
             ->willReturn(true);
@@ -636,7 +633,7 @@ final class CacheItemPoolDecoratorTest extends TestCase
     {
         $storage = $this->createMockedStorage(new AdapterOptions(['namespace' => '']));
         $storage
-            ->expects(self::once())
+            ->expects($this->once())
             ->method('flush')
             ->willThrowException(new Exception\RuntimeException());
         self::assertFalse($this->getAdapter($storage)->clear());
@@ -646,7 +643,7 @@ final class CacheItemPoolDecoratorTest extends TestCase
     {
         $storage = $this->createMockedStorage(new AdapterOptions(['namespace' => 'laminascache']));
         $storage
-            ->expects(self::once())
+            ->expects($this->once())
             ->method('clearByNamespace')
             ->with('laminascache')
             ->willReturn(true);
@@ -658,7 +655,7 @@ final class CacheItemPoolDecoratorTest extends TestCase
     {
         $storage = $this->createMockedStorage(new AdapterOptions(['namespace' => '']));
         $storage
-            ->expects(self::once())
+            ->expects($this->once())
             ->method('flush')
             ->willReturn(true);
 
@@ -669,7 +666,7 @@ final class CacheItemPoolDecoratorTest extends TestCase
     {
         $storage = $this->createMockedStorage(new AdapterOptions(['namespace' => 'laminascache']));
         $storage
-            ->expects(self::once())
+            ->expects($this->once())
             ->method('clearByNamespace')
             ->willThrowException(new Exception\RuntimeException());
         self::assertFalse($this->getAdapter($storage)->clear());
@@ -679,7 +676,7 @@ final class CacheItemPoolDecoratorTest extends TestCase
     {
         $storage = $this->storage;
         $storage
-            ->expects(self::once())
+            ->expects($this->once())
             ->method('removeItems')
             ->with(['foo'])
             ->willReturn([]);
@@ -691,7 +688,7 @@ final class CacheItemPoolDecoratorTest extends TestCase
     {
         $storage = $this->storage;
         $storage
-            ->expects(self::once())
+            ->expects($this->once())
             ->method('hasItem')
             ->with('foo')
             ->willReturn(false);
@@ -703,9 +700,7 @@ final class CacheItemPoolDecoratorTest extends TestCase
         self::assertFalse($adapter->hasItem('foo'));
     }
 
-    /**
-     * @dataProvider invalidKeyProvider
-     */
+    #[DataProvider('invalidKeyProvider')]
     public function testDeleteItemInvalidKeyThrowsException(mixed $key)
     {
         $this->expectException(InvalidArgumentException::class);
@@ -717,7 +712,7 @@ final class CacheItemPoolDecoratorTest extends TestCase
     {
         $storage = $this->storage;
         $storage
-            ->expects(self::once())
+            ->expects($this->once())
             ->method('removeItems')
             ->willThrowException(new Exception\RuntimeException());
         self::assertFalse($this->getAdapter($storage)->deleteItem('foo'));
@@ -728,7 +723,7 @@ final class CacheItemPoolDecoratorTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
         $storage = $this->storage;
         $storage
-            ->expects(self::once())
+            ->expects($this->once())
             ->method('removeItems')
             ->willThrowException(new Exception\InvalidArgumentException());
         $this->getAdapter($storage)->deleteItem('foo');
@@ -738,7 +733,7 @@ final class CacheItemPoolDecoratorTest extends TestCase
     {
         $storage = $this->storage;
         $storage
-            ->expects(self::once())
+            ->expects($this->once())
             ->method('removeItems')
             ->with(['foo', 'bar', 'baz'])
             ->willReturn([]);
@@ -796,7 +791,7 @@ final class CacheItemPoolDecoratorTest extends TestCase
     {
         $storage = $this->storage;
         $storage
-            ->expects(self::once())
+            ->expects($this->once())
             ->method('removeItems')
             ->willThrowException(new Exception\RuntimeException());
         self::assertFalse($this->getAdapter($storage)->deleteItems(['foo', 'bar', 'baz']));
@@ -807,7 +802,7 @@ final class CacheItemPoolDecoratorTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
         $storage = $this->storage;
         $storage
-            ->expects(self::once())
+            ->expects($this->once())
             ->method('removeItems')
             ->willThrowException(new Exception\InvalidArgumentException());
         $this->getAdapter($storage)->deleteItems(['foo', 'bar', 'baz']);
@@ -835,7 +830,7 @@ final class CacheItemPoolDecoratorTest extends TestCase
         $storage = $this->storage;
         $adapter = $this->getAdapter($storage);
         $storage
-            ->expects(self::once())
+            ->expects($this->once())
             ->method('setItems')
             ->with(['foo' => null])
             ->willReturn(['foo' => true]);
@@ -855,7 +850,7 @@ final class CacheItemPoolDecoratorTest extends TestCase
     {
         $storage = $this->storage;
         $storage
-            ->expects(self::once())
+            ->expects($this->once())
             ->method('setItems')
             ->willThrowException(new Exception\RuntimeException());
 
@@ -911,21 +906,19 @@ final class CacheItemPoolDecoratorTest extends TestCase
         parent::tearDown();
     }
 
-    /**
-     * @dataProvider deletionVerificationProvider
-     */
+    #[DataProvider('deletionVerificationProvider')]
     public function testWillVerifyKeyExistenceByUsingHasItemsWhenDeletionWasNotSuccessful(
         bool $exists,
         bool $successful,
     ): void {
         $this->storage
-            ->expects(self::once())
+            ->expects($this->once())
             ->method('removeItems')
             ->with(['foo'])
             ->willReturn(['foo']);
 
         $this->storage
-            ->expects(self::once())
+            ->expects($this->once())
             ->method('hasItems')
             ->with(['foo'])
             ->willReturn(['foo' => $exists]);
@@ -950,7 +943,7 @@ final class CacheItemPoolDecoratorTest extends TestCase
             ->method('setItem');
 
         $adapter
-            ->expects(self::once())
+            ->expects($this->once())
             ->method('hasItem')
             ->with('foo')
             ->willReturn(false);
@@ -1045,7 +1038,7 @@ final class CacheItemPoolDecoratorTest extends TestCase
         $this->adapter->saveDeferred($succeededItem);
 
         $this->storage
-            ->expects(self::once())
+            ->expects($this->once())
             ->method('setItems')
             ->willReturn(['keyOfFailedItem1', 'keyOfFailedItem2']);
 
@@ -1064,7 +1057,7 @@ final class CacheItemPoolDecoratorTest extends TestCase
 
         $now = new DateTimeImmutable('now');
         $clock
-            ->expects(self::once())
+            ->expects($this->once())
             ->method('now')
             ->willReturn($now);
 

--- a/test/Psr/CacheItemPool/CacheItemTest.php
+++ b/test/Psr/CacheItemPool/CacheItemTest.php
@@ -13,10 +13,11 @@ use Laminas\Cache\Psr\CacheItemPool\InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 use Psr\Clock\ClockInterface;
 
+use function assert;
 use function date_default_timezone_get;
 use function date_default_timezone_set;
 
-class CacheItemTest extends TestCase
+final class CacheItemTest extends TestCase
 {
     /** @var non-empty-string */
     private string $tz;
@@ -107,8 +108,10 @@ class CacheItemTest extends TestCase
 
     public function testExpiresAfterStartsExpiringAfterMethodCall(): void
     {
-        $now              = new DateTimeImmutable();
-        $nowPlusOneSecond = $now->add(DateInterval::createFromDateString('1 second'));
+        $now      = new DateTimeImmutable();
+        $interval = DateInterval::createFromDateString('1 second');
+        assert($interval instanceof DateInterval);
+        $nowPlusOneSecond = $now->add($interval);
 
         $clock = $this->createMock(ClockInterface::class);
         $clock
@@ -137,6 +140,7 @@ class CacheItemTest extends TestCase
         );
 
         $interval = DateInterval::createFromDateString('1 hour');
+        assert($interval instanceof DateInterval);
         $item->expiresAfter($interval);
 
         self::assertEquals(3600, $item->getTtl());

--- a/test/Psr/CacheItemPool/CacheItemTest.php
+++ b/test/Psr/CacheItemPool/CacheItemTest.php
@@ -13,7 +13,6 @@ use Laminas\Cache\Psr\CacheItemPool\InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 use Psr\Clock\ClockInterface;
 
-use function assert;
 use function date_default_timezone_get;
 use function date_default_timezone_set;
 
@@ -108,10 +107,8 @@ final class CacheItemTest extends TestCase
 
     public function testExpiresAfterStartsExpiringAfterMethodCall(): void
     {
-        $now      = new DateTimeImmutable();
-        $interval = DateInterval::createFromDateString('1 second');
-        assert($interval instanceof DateInterval);
-        $nowPlusOneSecond = $now->add($interval);
+        $now              = new DateTimeImmutable();
+        $nowPlusOneSecond = $now->add(new DateInterval('PT1S'));
 
         $clock = $this->createMock(ClockInterface::class);
         $clock
@@ -139,8 +136,7 @@ final class CacheItemTest extends TestCase
             }
         );
 
-        $interval = DateInterval::createFromDateString('1 hour');
-        assert($interval instanceof DateInterval);
+        $interval = new DateInterval('PT1H');
         $item->expiresAfter($interval);
 
         self::assertEquals(3600, $item->getTtl());

--- a/test/Psr/SimpleCache/SimpleCacheDecoratorTest.php
+++ b/test/Psr/SimpleCache/SimpleCacheDecoratorTest.php
@@ -15,6 +15,7 @@ use Laminas\Cache\Storage\Capabilities;
 use Laminas\Cache\Storage\StorageInterface;
 use LaminasTest\Cache\Psr\TestAsset\FlushableNamespaceStorageInterface;
 use LaminasTest\Cache\Psr\TestAsset\FlushableStorageInterface;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\SimpleCache\CacheException as PsrSimpleCacheException;
@@ -192,7 +193,7 @@ final class SimpleCacheDecoratorTest extends TestCase
         $testCase = $this;
         $cache    = $this->cache;
         $this->storage
-            ->expects(self::once())
+            ->expects($this->once())
             ->method('getItem')
             ->with('key')
             ->willReturnCallback(static function () use ($testCase, $cache) {
@@ -210,7 +211,7 @@ final class SimpleCacheDecoratorTest extends TestCase
         $testCase = $this;
         $cache    = $this->cache;
         $this->storage
-            ->expects(self::once())
+            ->expects($this->once())
             ->method('getItem')
             ->with('key')
             ->willReturnCallback(static function () use ($testCase, $cache): bool {
@@ -229,7 +230,7 @@ final class SimpleCacheDecoratorTest extends TestCase
         $expected = 'returned value';
 
         $this->storage
-            ->expects(self::once())
+            ->expects($this->once())
             ->method('getItem')
             ->with('key')
             ->willReturnCallback(static function () use ($testCase, $cache, $expected): string {
@@ -245,7 +246,7 @@ final class SimpleCacheDecoratorTest extends TestCase
     {
         $exception = new Exception\ExtensionNotLoadedException('failure', 500);
         $this->storage
-            ->expects(self::once())
+            ->expects($this->once())
             ->method('getItem')
             ->with('key')
             ->willThrowException($exception);
@@ -266,7 +267,7 @@ final class SimpleCacheDecoratorTest extends TestCase
         $ttl         = 86400;
 
         $this->options
-            ->expects(self::once())
+            ->expects($this->once())
             ->method('getTtl')
             ->willReturn($originalTtl);
 
@@ -289,12 +290,12 @@ final class SimpleCacheDecoratorTest extends TestCase
             ->willReturnSelf();
 
         $this->storage
-            ->expects(self::once())
+            ->expects($this->once())
             ->method('getOptions')
             ->willReturn($this->options);
 
         $this->storage
-            ->expects(self::once())
+            ->expects($this->once())
             ->method('setItem')
             ->with('key', 'value')
             ->willReturn(true);
@@ -303,9 +304,9 @@ final class SimpleCacheDecoratorTest extends TestCase
     }
 
     /**
-     * @dataProvider invalidatingTtls
      * @param int $ttl
      */
+    #[DataProvider('invalidatingTtls')]
     public function testSetShouldRemoveItemFromCacheIfTtlIsBelow1($ttl)
     {
         $this->storage
@@ -316,7 +317,7 @@ final class SimpleCacheDecoratorTest extends TestCase
             ->method('setItem');
 
         $this->storage
-            ->expects(self::once())
+            ->expects($this->once())
             ->method('removeItem')
             ->with('key')
             ->willReturn(true);
@@ -341,9 +342,7 @@ final class SimpleCacheDecoratorTest extends TestCase
         self::assertFalse($cache->set('key', 'value', 3600));
     }
 
-    /**
-     * @dataProvider invalidatingTtls
-     */
+    #[DataProvider('invalidatingTtls')]
     public function testSetShouldRemoveItemFromCacheIfTtlIsBelow1AndStorageDoesNotSupportTtl(int $ttl): void
     {
         $storage = $this->createMock(StorageInterface::class);
@@ -357,7 +356,7 @@ final class SimpleCacheDecoratorTest extends TestCase
             ->method('setItem');
 
         $storage
-            ->expects(self::once())
+            ->expects($this->once())
             ->method('removeItem')
             ->with('key')
             ->willReturn(true);
@@ -368,10 +367,10 @@ final class SimpleCacheDecoratorTest extends TestCase
     }
 
     /**
-     * @dataProvider invalidKeyProvider
      * @param string $key
      * @param string $expectedMessage
      */
+    #[DataProvider('invalidKeyProvider')]
     public function testSetShouldRaisePsrInvalidArgumentExceptionForInvalidKeys($key, $expectedMessage)
     {
         $this->storage
@@ -395,7 +394,7 @@ final class SimpleCacheDecoratorTest extends TestCase
 
         $this->mockCapabilities($storage, null, true, 251);
         $storage
-            ->expects(self::once())
+            ->expects($this->once())
             ->method('setItem')
             ->with($validKeyLength, 'value')
             ->willReturn(true);
@@ -416,7 +415,7 @@ final class SimpleCacheDecoratorTest extends TestCase
         $ttl         = 86400;
 
         $this->options
-            ->expects(self::once())
+            ->expects($this->once())
             ->method('getTtl')
             ->willReturn($originalTtl);
 
@@ -439,13 +438,13 @@ final class SimpleCacheDecoratorTest extends TestCase
             ->willReturnSelf();
 
         $this->storage
-            ->expects(self::once())
+            ->expects($this->once())
             ->method('getOptions')
             ->willReturn($this->options);
 
         $exception = new Exception\ExtensionNotLoadedException('failure', 500);
         $this->storage
-            ->expects(self::once())
+            ->expects($this->once())
             ->method('setItem')
             ->with('key', 'value')
             ->willThrowException($exception);
@@ -463,7 +462,7 @@ final class SimpleCacheDecoratorTest extends TestCase
     public function testDeleteShouldProxyToStorage(): void
     {
         $this->storage
-            ->expects(self::once())
+            ->expects($this->once())
             ->method('removeItem')
             ->with('key')
             ->willReturn(true);
@@ -474,7 +473,7 @@ final class SimpleCacheDecoratorTest extends TestCase
     public function testDeleteShouldReturnTrueWhenItemDoesNotExist(): void
     {
         $this->storage
-            ->expects(self::once())
+            ->expects($this->once())
             ->method('removeItem')
             ->with('key')
             ->willReturn(false);
@@ -485,7 +484,7 @@ final class SimpleCacheDecoratorTest extends TestCase
     {
         $exception = new Exception\ExtensionNotLoadedException('failure', 500);
         $this->storage
-            ->expects(self::once())
+            ->expects($this->once())
             ->method('removeItem')
             ->with('key')
             ->willThrowException($exception);
@@ -496,13 +495,13 @@ final class SimpleCacheDecoratorTest extends TestCase
     public function testClearReturnsFalseIfStorageIsNotFlushable(): void
     {
         $this->options
-            ->expects(self::once())
+            ->expects($this->once())
             ->method('getNamespace')
             ->willReturn('');
 
         $storage = $this->createMock(StorageInterface::class);
         $storage
-            ->expects(self::once())
+            ->expects($this->once())
             ->method('getOptions')
             ->willReturn($this->options);
 
@@ -515,7 +514,7 @@ final class SimpleCacheDecoratorTest extends TestCase
     public function testClearProxiesToStorageIfStorageCanBeClearedByNamespace(): void
     {
         $this->options
-            ->expects(self::once())
+            ->expects($this->once())
             ->method('getNamespace')
             ->willReturn('foo');
 
@@ -523,12 +522,12 @@ final class SimpleCacheDecoratorTest extends TestCase
 
         $this->mockCapabilities($storage);
         $storage
-            ->expects(self::once())
+            ->expects($this->once())
             ->method('getOptions')
             ->willReturn($this->options);
 
         $storage
-            ->expects(self::once())
+            ->expects($this->once())
             ->method('clearByNamespace')
             ->with('foo')
             ->willReturn(true);
@@ -544,7 +543,7 @@ final class SimpleCacheDecoratorTest extends TestCase
     public function testClearProxiesToStorageFlushIfStorageCanBeClearedByNamespaceWithNoNamespace(): void
     {
         $this->options
-            ->expects(self::once())
+            ->expects($this->once())
             ->method('getNamespace')
             ->willReturn('');
 
@@ -552,7 +551,7 @@ final class SimpleCacheDecoratorTest extends TestCase
 
         $this->mockCapabilities($storage);
         $storage
-            ->expects(self::once())
+            ->expects($this->once())
             ->method('getOptions')
             ->willReturn($this->options);
 
@@ -561,7 +560,7 @@ final class SimpleCacheDecoratorTest extends TestCase
             ->method('clearByNamespace');
 
         $storage
-            ->expects(self::once())
+            ->expects($this->once())
             ->method('flush')
             ->willReturn(true);
 
@@ -574,12 +573,12 @@ final class SimpleCacheDecoratorTest extends TestCase
         $storage = $this->createMock(FlushableStorageInterface::class);
         $this->mockCapabilities($storage);
         $storage
-            ->expects(self::once())
+            ->expects($this->once())
             ->method('getOptions')
             ->willReturn($this->options);
 
         $storage
-            ->expects(self::once())
+            ->expects($this->once())
             ->method('flush')
             ->willReturn(true);
 
@@ -597,7 +596,7 @@ final class SimpleCacheDecoratorTest extends TestCase
         ];
 
         $this->storage
-            ->expects(self::once())
+            ->expects($this->once())
             ->method('getItems')
             ->with($keys)
             ->willReturn([
@@ -618,7 +617,7 @@ final class SimpleCacheDecoratorTest extends TestCase
         ];
 
         $this->storage
-            ->expects(self::once())
+            ->expects($this->once())
             ->method('getItems')
             ->with($keys)
             ->willReturn([
@@ -639,7 +638,7 @@ final class SimpleCacheDecoratorTest extends TestCase
         ];
 
         $this->storage
-            ->expects(self::once())
+            ->expects($this->once())
             ->method('getItems')
             ->with(iterator_to_array($keys))
             ->willReturn($expected);
@@ -653,7 +652,7 @@ final class SimpleCacheDecoratorTest extends TestCase
         $exception = new Exception\ExtensionNotLoadedException('failure', 500);
 
         $this->storage
-            ->expects(self::once())
+            ->expects($this->once())
             ->method('getItems')
             ->with($keys)
             ->willThrowException($exception);
@@ -674,7 +673,7 @@ final class SimpleCacheDecoratorTest extends TestCase
         $ttl         = 86400;
 
         $this->options
-            ->expects(self::once())
+            ->expects($this->once())
             ->method('getTtl')
             ->willReturn($originalTtl);
 
@@ -697,14 +696,14 @@ final class SimpleCacheDecoratorTest extends TestCase
             ->willReturnSelf();
 
         $this->storage
-            ->expects(self::once())
+            ->expects($this->once())
             ->method('getOptions')
             ->willReturn($this->options);
 
         $values = ['one' => 1, 'three' => 3];
 
         $this->storage
-            ->expects(self::once())
+            ->expects($this->once())
             ->method('setItems')
             ->with($values)
             ->willReturn([]);
@@ -718,7 +717,7 @@ final class SimpleCacheDecoratorTest extends TestCase
         $ttl         = 86400;
 
         $this->options
-            ->expects(self::once())
+            ->expects($this->once())
             ->method('getTtl')
             ->willReturn($originalTtl);
 
@@ -741,7 +740,7 @@ final class SimpleCacheDecoratorTest extends TestCase
             ->willReturnSelf();
 
         $this->storage
-            ->expects(self::once())
+            ->expects($this->once())
             ->method('getOptions')
             ->willReturn($this->options);
 
@@ -751,7 +750,7 @@ final class SimpleCacheDecoratorTest extends TestCase
         ]);
 
         $this->storage
-            ->expects(self::once())
+            ->expects($this->once())
             ->method('setItems')
             ->with(iterator_to_array($values))
             ->willReturn([]);
@@ -760,9 +759,9 @@ final class SimpleCacheDecoratorTest extends TestCase
     }
 
     /**
-     * @dataProvider invalidatingTtls
      * @param int $ttl
      */
+    #[DataProvider('invalidatingTtls')]
     public function testSetMultipleShouldRemoveItemsFromCacheIfTtlIsBelow1($ttl)
     {
         $values = [
@@ -779,7 +778,7 @@ final class SimpleCacheDecoratorTest extends TestCase
             ->method('setItems');
 
         $this->storage
-            ->expects(self::once())
+            ->expects($this->once())
             ->method('removeItems')
             ->with(array_keys($values))->willReturn([]);
 
@@ -809,9 +808,7 @@ final class SimpleCacheDecoratorTest extends TestCase
         self::assertFalse($cache->setMultiple($values, 60));
     }
 
-    /**
-     * @dataProvider invalidatingTtls
-     */
+    #[DataProvider('invalidatingTtls')]
     public function testSetMultipleShouldRemoveItemsFromCacheIfTtlIsBelow1AndStorageDoesNotSupportTtl(int $ttl): void
     {
         $values = [
@@ -831,7 +828,7 @@ final class SimpleCacheDecoratorTest extends TestCase
             ->method('setItems');
 
         $storage
-            ->expects(self::once())
+            ->expects($this->once())
             ->method('removeItems')
             ->with(array_keys($values))
             ->willReturn([]);
@@ -842,10 +839,10 @@ final class SimpleCacheDecoratorTest extends TestCase
     }
 
     /**
-     * @dataProvider invalidKeyProvider
      * @param string $key
      * @param string $expectedMessage
      */
+    #[DataProvider('invalidKeyProvider')]
     public function testSetMultipleShouldRaisePsrInvalidArgumentExceptionForInvalidKeys($key, $expectedMessage)
     {
         $this->storage
@@ -863,7 +860,7 @@ final class SimpleCacheDecoratorTest extends TestCase
         $ttl         = 86400;
 
         $this->options
-            ->expects(self::once())
+            ->expects($this->once())
             ->method('getTtl')
             ->willReturn($originalTtl);
 
@@ -886,7 +883,7 @@ final class SimpleCacheDecoratorTest extends TestCase
             ->willReturnSelf();
 
         $this->storage
-            ->expects(self::once())
+            ->expects($this->once())
             ->method('getOptions')
             ->willReturn($this->options);
 
@@ -894,7 +891,7 @@ final class SimpleCacheDecoratorTest extends TestCase
         $values    = ['one' => 1, 'three' => 3];
 
         $this->storage
-            ->expects(self::once())
+            ->expects($this->once())
             ->method('setItems')
             ->with($values)
             ->willThrowException($exception);
@@ -913,7 +910,7 @@ final class SimpleCacheDecoratorTest extends TestCase
     {
         $keys = ['one', 'two', 'three'];
         $this->storage
-            ->expects(self::once())
+            ->expects($this->once())
             ->method('removeItems')
             ->with($keys)
             ->willReturn([]);
@@ -924,7 +921,7 @@ final class SimpleCacheDecoratorTest extends TestCase
     {
         $keys = new ArrayIterator(['one', 'two', 'three']);
         $this->storage
-            ->expects(self::once())
+            ->expects($this->once())
             ->method('removeItems')
             ->with(iterator_to_array($keys))
             ->willReturn([]);
@@ -945,13 +942,13 @@ final class SimpleCacheDecoratorTest extends TestCase
     {
         $keys = ['one', 'two', 'three'];
         $this->storage
-            ->expects(self::once())
+            ->expects($this->once())
             ->method('removeItems')
             ->with($keys)
             ->willReturn(['two']);
 
         $this->storage
-            ->expects(self::once())
+            ->expects($this->once())
             ->method('hasItem')
             ->with('two')
             ->willReturn(true);
@@ -963,13 +960,13 @@ final class SimpleCacheDecoratorTest extends TestCase
     {
         $keys = ['one', 'two', 'three'];
         $this->storage
-            ->expects(self::once())
+            ->expects($this->once())
             ->method('removeItems')
             ->with($keys)
             ->willReturn(['two']);
 
         $this->storage
-            ->expects(self::once())
+            ->expects($this->once())
             ->method('hasItem')
             ->with('two')
             ->willReturn(false);
@@ -982,7 +979,7 @@ final class SimpleCacheDecoratorTest extends TestCase
         $keys      = ['one', 'two', 'three'];
         $exception = new Exception\InvalidArgumentException('bad key', 500);
         $this->storage
-            ->expects(self::once())
+            ->expects($this->once())
             ->method('removeItems')
             ->with($keys)
             ->willThrowException($exception);
@@ -1001,13 +998,11 @@ final class SimpleCacheDecoratorTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider hasResultProvider
-     */
+    #[DataProvider('hasResultProvider')]
     public function testHasProxiesToStorage(bool $result)
     {
         $this->storage
-            ->expects(self::once())
+            ->expects($this->once())
             ->method('hasItem')
             ->with('key')
             ->willReturn($result);
@@ -1019,7 +1014,7 @@ final class SimpleCacheDecoratorTest extends TestCase
     {
         $exception = new Exception\ExtensionNotLoadedException('failure', 500);
         $this->storage
-            ->expects(self::once())
+            ->expects($this->once())
             ->method('hasItem')
             ->with('key')
             ->willThrowException($exception);
@@ -1064,22 +1059,22 @@ final class SimpleCacheDecoratorTest extends TestCase
     public function testUseTtlFromOptionsOnSetMocking(): void
     {
         $this->options
-            ->expects(self::once())
+            ->expects($this->once())
             ->method('getTtl')
             ->willReturn(40);
 
         $this->options
-            ->expects(self::once())
+            ->expects($this->once())
             ->method('setTtl')
             ->with(40)
             ->willReturnSelf();
 
         $this->storage
-            ->expects(self::once())
+            ->expects($this->once())
             ->method('getOptions')
             ->willReturn($this->options);
         $this->storage
-            ->expects(self::once())
+            ->expects($this->once())
             ->method('setItem')
             ->with('foo', 'bar')
             ->willReturn(true);
@@ -1090,22 +1085,22 @@ final class SimpleCacheDecoratorTest extends TestCase
     public function testUseTtlFromOptionsOnSetMultipleMocking(): void
     {
         $this->options
-            ->expects(self::once())
+            ->expects($this->once())
             ->method('getTtl')
             ->willReturn(40);
         $this->options
-            ->expects(self::once())
+            ->expects($this->once())
             ->method('setTtl')
             ->with(40)
             ->willReturnSelf();
 
         $this->storage
-            ->expects(self::once())
+            ->expects($this->once())
             ->method('getOptions')
             ->willReturn($this->options);
 
         $this->storage
-            ->expects(self::once())
+            ->expects($this->once())
             ->method('setItems')
             ->with(['foo' => 'bar', 'boo' => 'baz'])
             ->willReturn([]);
@@ -1113,9 +1108,7 @@ final class SimpleCacheDecoratorTest extends TestCase
         self::assertTrue($this->cache->setMultiple(['foo' => 'bar', 'boo' => 'baz']));
     }
 
-    /**
-     * @dataProvider unsupportedCapabilities
-     */
+    #[DataProvider('unsupportedCapabilities')]
     public function testWillThrowExceptionWhenStorageDoesNotFulfillMinimumRequirements(Capabilities $capabilities): void
     {
         $storage = $this->createMock(StorageInterface::class);
@@ -1193,7 +1186,7 @@ final class SimpleCacheDecoratorTest extends TestCase
     {
         $storage = $this->storage;
         $this->storage
-            ->expects(self::once())
+            ->expects($this->once())
             ->method('getItem')
             ->willThrowException(new Exception\InvalidArgumentException());
 
@@ -1207,7 +1200,7 @@ final class SimpleCacheDecoratorTest extends TestCase
     {
         $storage = $this->storage;
         $storage
-            ->expects(self::once())
+            ->expects($this->once())
             ->method('getItem')
             ->willThrowException(new SimpleCacheException());
 

--- a/test/Psr/SimpleCache/TestAsset/TtlStorage.php
+++ b/test/Psr/SimpleCache/TestAsset/TtlStorage.php
@@ -12,7 +12,7 @@ use Laminas\Cache\Storage\Capabilities;
  * @template TOptions of AdapterOptions
  * @template-extends Adapter\AbstractAdapter<TOptions>
  */
-class TtlStorage extends Adapter\AbstractAdapter
+final class TtlStorage extends Adapter\AbstractAdapter
 {
     private array $data = [];
 

--- a/test/Service/ConfigProviderIntegrationTest.php
+++ b/test/Service/ConfigProviderIntegrationTest.php
@@ -8,6 +8,7 @@ use Generator;
 use InvalidArgumentException;
 use Laminas\Cache\ConfigProvider;
 use Laminas\ServiceManager\ServiceManager;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
 
@@ -32,9 +33,7 @@ final class ConfigProviderIntegrationTest extends TestCase
         return new ServiceManager((new ConfigProvider())->getDependencyConfig());
     }
 
-    /**
-     * @dataProvider servicesProvidedByConfigProvider
-     */
+    #[DataProvider('servicesProvidedByConfigProvider')]
     public function testContainerCanProvideRegisteredServices(string $serviceName): void
     {
         $instance = $this->container->get($serviceName);

--- a/test/Service/StorageAdapterFactoryTest.php
+++ b/test/Service/StorageAdapterFactoryTest.php
@@ -15,6 +15,7 @@ use Laminas\Cache\Storage\Plugin\PluginInterface;
 use Laminas\Cache\Storage\PluginAwareInterface;
 use Laminas\Cache\Storage\StorageInterface;
 use Laminas\ServiceManager\PluginManagerInterface;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
@@ -116,15 +117,15 @@ final class StorageAdapterFactoryTest extends TestCase
     /**
      * @psalm-param non-empty-string $adapterName
      * @param array<string,mixed> $adapterConfiguration
-     * @dataProvider storageConfigurations
      */
+    #[DataProvider('storageConfigurations')]
     public function testWillCreateStorageFromArrayConfiguration(
         string $adapterName,
         array $adapterConfiguration
     ): void {
         $adapterMock = $this->createMock(AbstractAdapter::class);
         $this->adapters
-            ->expects(self::once())
+            ->expects($this->once())
             ->method('build')
             ->with($adapterName, $adapterConfiguration)
             ->willReturn($adapterMock);
@@ -139,8 +140,8 @@ final class StorageAdapterFactoryTest extends TestCase
 
     /**
      * @psalm-param list<PluginArrayConfigurationWithPriorityType> $plugins
-     * @dataProvider pluginConfigurations
      */
+    #[DataProvider('pluginConfigurations')]
     public function testWillCreateAdapterAndAttachesPlugins(array $plugins): void
     {
         $adapterMock = $this->createMock(AbstractAdapter::class);
@@ -193,7 +194,7 @@ final class StorageAdapterFactoryTest extends TestCase
     {
         $storage = $this->createMock(StorageInterface::class);
         $this->adapters
-            ->expects(self::once())
+            ->expects($this->once())
             ->method('build')
             ->willReturn($storage);
 
@@ -205,8 +206,8 @@ final class StorageAdapterFactoryTest extends TestCase
     /**
      * @param array<mixed>  $invalidConfiguration
      * @psalm-param non-empty-string $expectedExceptionMessage
-     * @dataProvider invalidConfigurations
      */
+    #[DataProvider('invalidConfigurations')]
     public function testWillThrowInvalidArgumentExceptionWhenInvalidConfigurationsWherePassedToConfigurationAssertion(
         array $invalidConfiguration,
         string $expectedExceptionMessage
@@ -225,7 +226,7 @@ final class StorageAdapterFactoryTest extends TestCase
         );
 
         $this->plugins
-            ->expects(self::once())
+            ->expects($this->once())
             ->method('assertValidConfigurationStructure')
             ->with(['name' => ''])
             ->willThrowException(new InvalidArgumentException('ERROR FROM PLUGIN CONFIGURATION ASSERTION'));
@@ -246,7 +247,7 @@ final class StorageAdapterFactoryTest extends TestCase
         );
 
         $this->plugins
-            ->expects(self::once())
+            ->expects($this->once())
             ->method('assertValidConfigurationStructure');
 
         $this->factory->assertValidConfigurationStructure([

--- a/test/Service/StorageCacheAbstractServiceFactoryTest.php
+++ b/test/Service/StorageCacheAbstractServiceFactoryTest.php
@@ -64,7 +64,7 @@ final class StorageCacheAbstractServiceFactoryTest extends TestCase
     public function testCanRetrieveCacheByName(): void
     {
         $this->adapterFactory
-            ->expects(self::once())
+            ->expects($this->once())
             ->method('createFromArrayConfiguration')
             ->with($this->config['caches']['Memory'])
             ->willReturn($this->createMock(StorageInterface::class));
@@ -75,7 +75,7 @@ final class StorageCacheAbstractServiceFactoryTest extends TestCase
     public function testWillAssertConfigurationValidity(): void
     {
         $this->adapterFactory
-            ->expects(self::once())
+            ->expects($this->once())
             ->method('assertValidConfigurationStructure')
             ->with($this->config['caches']['Foo']);
 
@@ -86,7 +86,7 @@ final class StorageCacheAbstractServiceFactoryTest extends TestCase
     {
         $exception = new InvalidArgumentException();
         $this->adapterFactory
-            ->expects(self::once())
+            ->expects($this->once())
             ->method('assertValidConfigurationStructure')
             ->willThrowException($exception);
 

--- a/test/Service/StorageCacheFactoryTest.php
+++ b/test/Service/StorageCacheFactoryTest.php
@@ -38,7 +38,7 @@ final class StorageCacheFactoryTest extends TestCase
     {
         $factory = $this->createMock(StorageAdapterFactoryInterface::class);
         $factory
-            ->expects(self::once())
+            ->expects($this->once())
             ->method('createFromArrayConfiguration')
             ->with($this->config['cache'])
             ->willReturn($this->createMock(StorageInterface::class));
@@ -68,12 +68,12 @@ final class StorageCacheFactoryTest extends TestCase
     {
         $factory = $this->createMock(StorageAdapterFactoryInterface::class);
         $factory
-            ->expects(self::once())
+            ->expects($this->once())
             ->method('assertValidConfigurationStructure')
             ->with($this->config['cache']);
 
         $factory
-            ->expects(self::once())
+            ->expects($this->once())
             ->method('createFromArrayConfiguration')
             ->with($this->config['cache'])
             ->willReturn($this->createMock(StorageInterface::class));

--- a/test/Service/StoragePluginFactoryFactoryTest.php
+++ b/test/Service/StoragePluginFactoryFactoryTest.php
@@ -25,7 +25,7 @@ final class StoragePluginFactoryFactoryTest extends TestCase
         $plugins   = $this->createMock(PluginManagerInterface::class);
         $container = $this->createMock(ContainerInterface::class);
         $container
-            ->expects(self::once())
+            ->expects($this->once())
             ->method('get')
             ->with(PluginManager::class)
             ->willReturn($plugins);

--- a/test/Service/StoragePluginFactoryTest.php
+++ b/test/Service/StoragePluginFactoryTest.php
@@ -9,6 +9,7 @@ use Laminas\Cache\Exception\InvalidArgumentException;
 use Laminas\Cache\Service\StoragePluginFactory;
 use Laminas\Cache\Storage\Plugin\PluginInterface;
 use Laminas\ServiceManager\PluginManagerInterface;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
@@ -57,7 +58,7 @@ final class StoragePluginFactoryTest extends TestCase
         $plugin = $this->createMock(PluginInterface::class);
 
         $this->plugins
-            ->expects(self::once())
+            ->expects($this->once())
             ->method('build')
             ->with('foo')
             ->willReturn($plugin);
@@ -71,7 +72,7 @@ final class StoragePluginFactoryTest extends TestCase
         $plugin = $this->createMock(PluginInterface::class);
 
         $this->plugins
-            ->expects(self::once())
+            ->expects($this->once())
             ->method('build')
             ->with('foo', ['bar' => 'baz'])
             ->willReturn($plugin);
@@ -88,7 +89,7 @@ final class StoragePluginFactoryTest extends TestCase
         $plugin = $this->createMock(PluginInterface::class);
 
         $this->plugins
-            ->expects(self::once())
+            ->expects($this->once())
             ->method('build')
             ->with('foo')
             ->willReturn($plugin);
@@ -102,7 +103,7 @@ final class StoragePluginFactoryTest extends TestCase
         $plugin = $this->createMock(PluginInterface::class);
 
         $this->plugins
-            ->expects(self::once())
+            ->expects($this->once())
             ->method('build')
             ->with('foo', ['bar' => 'baz'])
             ->willReturn($plugin);
@@ -115,8 +116,8 @@ final class StoragePluginFactoryTest extends TestCase
     /**
      * @param array<mixed>  $invalidConfiguration
      * @psalm-param non-empty-string $expectedExceptionMessage
-     * @dataProvider invalidConfigurations
      */
+    #[DataProvider('invalidConfigurations')]
     public function testWillThrowInvalidArgumentExceptionWhenInvalidConfigurationIsPassedToConfigurationAssertion(
         array $invalidConfiguration,
         string $expectedExceptionMessage

--- a/test/Storage/Adapter/AbstractAdapterTest.php
+++ b/test/Storage/Adapter/AbstractAdapterTest.php
@@ -135,7 +135,7 @@ final class AbstractAdapterTest extends TestCase
         $event = current($calledEvents);
 
         // return value of triggerPost and the called event should be the same
-        self::assertSame($result, $event->getResult());
+        self::assertSame($result, $event !== false ? $event->getResult() : null);
 
         self::assertInstanceOf(PostEvent::class, $event);
         self::assertEquals('setItem.post', $event->getName());
@@ -238,7 +238,7 @@ final class AbstractAdapterTest extends TestCase
             ->expects($this->once())
             ->method('internalHasItem')
             ->with($this->equalTo($key))
-            ->will($this->returnValue($result));
+            ->willReturn($result);
 
         $rs = $storage->hasItem($key);
         self::assertSame($result, $rs);
@@ -255,7 +255,7 @@ final class AbstractAdapterTest extends TestCase
             ->expects($this->once())
             ->method('internalHasItems')
             ->with($this->equalTo($keys))
-            ->will($this->returnValue($result));
+            ->willReturn($result);
 
         $rs = $storage->hasItems($keys);
         self::assertEquals($result, $rs);
@@ -298,7 +298,8 @@ final class AbstractAdapterTest extends TestCase
             ->with($this->equalTo($key))
             ->willThrowException(new \Exception('internalGetItem failed'));
 
-        $result = $storage->getItem($key, $success);
+        $success = true;
+        $result  = $storage->getItem($key, $success);
         self::assertNull($result, 'GetItem should return null the item cannot be retrieved');
         self::assertFalse($success, '$success should be false if the item cannot be retrieved');
     }
@@ -763,20 +764,15 @@ final class AbstractAdapterTest extends TestCase
      */
     protected function getMockForAbstractAdapter(array $methods = []): MockObject&AbstractAdapter
     {
-        if (! $methods) {
-            $adapter = $this->getMockForAbstractClass(AbstractAdapter::class);
-        } else {
-            $reflection = new ReflectionClass(AbstractAdapter::class);
-            foreach ($reflection->getMethods() as $method) {
-                if ($method->isAbstract()) {
-                    $methods[] = $method->getName();
-                }
+        $reflection = new ReflectionClass(AbstractAdapter::class);
+        foreach ($reflection->getMethods() as $method) {
+            if ($method->isAbstract()) {
+                $methods[] = $method->getName();
             }
-            $adapter = $this->getMockBuilder(AbstractAdapter::class)
-                ->onlyMethods(array_values(array_unique($methods)))
-                ->disableArgumentCloning()
-                ->getMock();
         }
+        $adapter = $this->getMockBuilder(AbstractAdapter::class)
+            ->onlyMethods(array_values(array_unique($methods)))
+            ->getMock();
 
         $adapter->setOptions($this->options ?? new AdapterOptions());
 
@@ -789,13 +785,13 @@ final class AbstractAdapterTest extends TestCase
         $storage
             ->addPlugin(new Serializer(new AdapterPluginManager(new ServiceManager())));
         $storage
-            ->expects(self::once())
+            ->expects($this->once())
             ->method('internalSetItem')
             ->with('foo', serialize('baz'))
             ->willReturn(true);
 
         $storage
-            ->expects(self::once())
+            ->expects($this->once())
             ->method('internalGetItem')
             ->with('foo')
             ->willReturn(serialize('bar'));

--- a/test/Storage/Adapter/AbstractMetadataCapableAdapterTest.php
+++ b/test/Storage/Adapter/AbstractMetadataCapableAdapterTest.php
@@ -10,6 +10,7 @@ use Laminas\Cache\Storage\AbstractMetadataCapableAdapter;
 use Laminas\Cache\Storage\Adapter\AdapterOptions;
 use Laminas\Cache\Storage\Event;
 use Laminas\EventManager\EventInterface;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use ReflectionClass;
@@ -58,20 +59,15 @@ final class AbstractMetadataCapableAdapterTest extends TestCase
     private function getMockForAbstractMetadataCapableAdapter(
         array $methods = []
     ): MockObject&AbstractMetadataCapableAdapter {
-        if (! $methods) {
-            $adapter = $this->getMockForAbstractClass(AbstractMetadataCapableAdapter::class);
-        } else {
-            $reflection = new ReflectionClass(AbstractMetadataCapableAdapter::class);
-            foreach ($reflection->getMethods() as $method) {
-                if ($method->isAbstract()) {
-                    $methods[] = $method->getName();
-                }
+        $reflection = new ReflectionClass(AbstractMetadataCapableAdapter::class);
+        foreach ($reflection->getMethods() as $method) {
+            if ($method->isAbstract()) {
+                $methods[] = $method->getName();
             }
-            $adapter = $this->getMockBuilder(AbstractMetadataCapableAdapter::class)
-                ->onlyMethods(array_values(array_unique($methods)))
-                ->disableArgumentCloning()
-                ->getMock();
         }
+        $adapter = $this->getMockBuilder(AbstractMetadataCapableAdapter::class)
+            ->onlyMethods(array_values(array_unique($methods)))
+            ->getMock();
 
         $adapter->setOptions($this->options ?? new AdapterOptions());
 
@@ -81,8 +77,8 @@ final class AbstractMetadataCapableAdapterTest extends TestCase
     /**
      * @psalm-param non-empty-string $methodName
      * @psalm-param non-empty-string $internalMethodName
-     * @dataProvider simpleEventHandlingMethodDefinitions
      */
+    #[DataProvider('simpleEventHandlingMethodDefinitions')]
     public function testEventHandlingSimple(
         string $methodName,
         string $internalMethodName,
@@ -119,8 +115,8 @@ final class AbstractMetadataCapableAdapterTest extends TestCase
     /**
      * @psalm-param non-empty-string $methodName
      * @psalm-param non-empty-string $internalMethodName
-     * @dataProvider simpleEventHandlingMethodDefinitions
      */
+    #[DataProvider('simpleEventHandlingMethodDefinitions')]
     public function testEventHandlingCatchException(
         string $methodName,
         string $internalMethodName,
@@ -158,8 +154,8 @@ final class AbstractMetadataCapableAdapterTest extends TestCase
     /**
      * @psalm-param non-empty-string $methodName
      * @psalm-param non-empty-string $internalMethodName
-     * @dataProvider simpleEventHandlingMethodDefinitions
      */
+    #[DataProvider('simpleEventHandlingMethodDefinitions')]
     public function testEventHandlingStopInPre(
         string $methodName,
         string $internalMethodName,

--- a/test/Storage/Adapter/AdapterOptionsTest.php
+++ b/test/Storage/Adapter/AdapterOptionsTest.php
@@ -6,19 +6,19 @@ namespace LaminasTest\Cache\Storage\Adapter;
 
 use Laminas\Cache\Exception;
 use Laminas\Cache\Exception\InvalidArgumentException;
-use Laminas\Cache\Storage\Adapter\AbstractAdapter;
 use Laminas\Cache\Storage\Adapter\AdapterOptions;
 use Laminas\Cache\Storage\Event;
 use LaminasTest\Cache\Storage\Adapter\TestAsset\AdapterOptionsWithPrioritizedOptions;
+use LaminasTest\Cache\Storage\TestAsset\MockAdapter;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 
 use function func_get_args;
 
-/**
- * @group      Laminas_Cache
- * @covers Laminas\Cache\Storage\Adapter\AdapterOptions<extended>
- */
-class AdapterOptionsTest extends TestCase
+#[Group('Laminas_Cache')]
+#[CoversClass(AdapterOptions::class)]
+final class AdapterOptionsTest extends TestCase
 {
     protected AdapterOptions $options;
 
@@ -168,7 +168,7 @@ class AdapterOptionsTest extends TestCase
     public function testTriggerOptionEvent(): void
     {
         // setup an adapter implements EventsCapableInterface
-        $adapter = $this->getMockForAbstractClass(AbstractAdapter::class);
+        $adapter = new MockAdapter();
         $this->options->setAdapter($adapter);
 
         // setup event listener

--- a/test/Storage/Adapter/EventManagerCompatibilityTest.php
+++ b/test/Storage/Adapter/EventManagerCompatibilityTest.php
@@ -9,7 +9,7 @@ use Laminas\EventManager\EventManager;
 use LaminasTest\Cache\Storage\TestAsset\MockAdapter;
 use PHPUnit\Framework\TestCase;
 
-class EventManagerCompatibilityTest extends TestCase
+final class EventManagerCompatibilityTest extends TestCase
 {
     private MockAdapter $adapter;
 

--- a/test/Storage/Adapter/KeyListIteratorTest.php
+++ b/test/Storage/Adapter/KeyListIteratorTest.php
@@ -6,13 +6,13 @@ namespace LaminasTest\Cache\Storage\Adapter;
 
 use Laminas\Cache\Storage\Adapter\KeyListIterator;
 use Laminas\Cache\Storage\StorageInterface;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 
-/**
- * @group      Laminas_Cache
- * @covers \Laminas\Cache\Storage\Adapter\KeyListIterator
- */
-class KeyListIteratorTest extends TestCase
+#[Group('Laminas_Cache')]
+#[CoversClass(KeyListIterator::class)]
+final class KeyListIteratorTest extends TestCase
 {
     public function testCount(): void
     {

--- a/test/Storage/Adapter/TestAsset/AdapterWithStorageAndEventsCapableInterface.php
+++ b/test/Storage/Adapter/TestAsset/AdapterWithStorageAndEventsCapableInterface.php
@@ -19,6 +19,7 @@ interface AdapterWithStorageAndEventsCapableInterface extends StorageInterface, 
 
     /**
      * @param int $priority
+     * @return self
      */
     public function addPlugin(PluginInterface $plugin, $priority = 1);
 }

--- a/test/Storage/AdapterPluginManagerTest.php
+++ b/test/Storage/AdapterPluginManagerTest.php
@@ -12,7 +12,7 @@ use Laminas\ServiceManager\Test\CommonPluginManagerTrait;
 use PHPUnit\Framework\Attributes\RequiresPhp;
 use PHPUnit\Framework\TestCase;
 
-class AdapterPluginManagerTest extends TestCase
+final class AdapterPluginManagerTest extends TestCase
 {
     use CommonPluginManagerTrait {
         testPluginAliasesResolve as commonPluginAliasesResolve;
@@ -25,7 +25,7 @@ class AdapterPluginManagerTest extends TestCase
      * We cannot delete the method either and nor can we skip it inside the method due to the method parameter
      * requirements.
      *
-     * @psalm-suppress PossiblyUnusedParam
+     * @psalm-suppress UnusedParam
      */
     #[RequiresPhp('<8.0')]
     public function testPluginAliasesResolve(string $alias, string $expected)

--- a/test/Storage/Plugin/AbstractCommonPluginTestCase.php
+++ b/test/Storage/Plugin/AbstractCommonPluginTestCase.php
@@ -8,6 +8,7 @@ use Laminas\Cache\Storage\Plugin\PluginInterface;
 use Laminas\Cache\Storage\Plugin\PluginOptions;
 use Laminas\Cache\Storage\PluginManager;
 use Laminas\ServiceManager\ServiceManager;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 abstract class AbstractCommonPluginTestCase extends TestCase
@@ -21,9 +22,7 @@ abstract class AbstractCommonPluginTestCase extends TestCase
      */
     abstract public static function getCommonPluginNamesProvider(): iterable;
 
-    /**
-     * @dataProvider getCommonPluginNamesProvider
-     */
+    #[DataProvider('getCommonPluginNamesProvider')]
     public function testPluginManagerWithCommonNames(string $commonPluginName): void
     {
         $pluginManager = new PluginManager(new ServiceManager());

--- a/test/Storage/Plugin/ClearExpiredByFactorTest.php
+++ b/test/Storage/Plugin/ClearExpiredByFactorTest.php
@@ -63,9 +63,9 @@ final class ClearExpiredByFactorTest extends AbstractCommonPluginTestCase
             // check expected callback method
             $cb = array_shift($listeners);
             self::assertArrayHasKey(0, $cb);
-            self::assertSame($this->plugin, $cb[0]);
+            self::assertSame($this->plugin, $cb[0] ?? null);
             self::assertArrayHasKey(1, $cb);
-            self::assertSame($expectedCallbackMethod, $cb[1]);
+            self::assertSame($expectedCallbackMethod, $cb[1] ?? null);
         }
     }
 
@@ -87,7 +87,7 @@ final class ClearExpiredByFactorTest extends AbstractCommonPluginTestCase
 
         // test clearByNamespace will be called
         $adapter
-            ->expects(self::once())
+            ->expects($this->once())
             ->method('clearExpired')
             ->willReturn(true);
 

--- a/test/Storage/Plugin/ExceptionHandlerTest.php
+++ b/test/Storage/Plugin/ExceptionHandlerTest.php
@@ -76,9 +76,9 @@ final class ExceptionHandlerTest extends AbstractCommonPluginTestCase
             // check expected callback method
             $cb = array_shift($listeners);
             self::assertArrayHasKey(0, $cb);
-            self::assertSame($this->plugin, $cb[0]);
+            self::assertSame($this->plugin, $cb[0] ?? null);
             self::assertArrayHasKey(1, $cb);
-            self::assertSame($expectedCallbackMethod, $cb[1]);
+            self::assertSame($expectedCallbackMethod, $cb[1] ?? null);
         }
     }
 

--- a/test/Storage/Plugin/IgnoreUserAbortTest.php
+++ b/test/Storage/Plugin/IgnoreUserAbortTest.php
@@ -8,6 +8,7 @@ use Laminas\Cache;
 use Laminas\Cache\Storage\Adapter\AbstractAdapter;
 use Laminas\Cache\Storage\Plugin\PluginOptions;
 use Laminas\EventManager\Test\EventListenerIntrospectionTrait;
+use LaminasTest\Cache\Storage\TestAsset\MockAdapter;
 
 use function array_shift;
 
@@ -21,7 +22,7 @@ final class IgnoreUserAbortTest extends AbstractCommonPluginTestCase
 
     protected function setUp(): void
     {
-        $this->adapter = $this->getMockForAbstractClass(AbstractAdapter::class);
+        $this->adapter = new MockAdapter();
         $this->options = new Cache\Storage\Plugin\PluginOptions();
         $this->plugin  = new Cache\Storage\Plugin\IgnoreUserAbort();
         $this->plugin->setOptions($this->options);
@@ -74,9 +75,9 @@ final class IgnoreUserAbortTest extends AbstractCommonPluginTestCase
             // check expected callback method
             $cb = array_shift($listeners);
             self::assertArrayHasKey(0, $cb);
-            self::assertSame($this->plugin, $cb[0]);
+            self::assertSame($this->plugin, $cb[0] ?? null);
             self::assertArrayHasKey(1, $cb);
-            self::assertSame($expectedCallbackMethod, $cb[1]);
+            self::assertSame($expectedCallbackMethod, $cb[1] ?? null);
         }
     }
 

--- a/test/Storage/Plugin/OptimizeByFactorTest.php
+++ b/test/Storage/Plugin/OptimizeByFactorTest.php
@@ -59,9 +59,9 @@ final class OptimizeByFactorTest extends AbstractCommonPluginTestCase
             // check expected callback method
             $cb = array_shift($listeners);
             self::assertArrayHasKey(0, $cb);
-            self::assertSame($this->plugin, $cb[0]);
+            self::assertSame($this->plugin, $cb[0] ?? null);
             self::assertArrayHasKey(1, $cb);
-            self::assertSame($expectedCallbackMethod, $cb[1]);
+            self::assertSame($expectedCallbackMethod, $cb[1] ?? null);
         }
     }
 

--- a/test/Storage/Plugin/SerializerTest.php
+++ b/test/Storage/Plugin/SerializerTest.php
@@ -73,15 +73,15 @@ final class SerializerTest extends AbstractCommonPluginTestCase
             // check expected callback method
             $cb = array_shift($listeners);
             self::assertArrayHasKey(0, $cb);
-            self::assertSame($this->plugin, $cb[0]);
+            self::assertSame($this->plugin, $cb[0] ?? null);
             self::assertArrayHasKey(1, $cb);
-            self::assertSame($expectedCallbackMethod, $cb[1]);
+            self::assertSame($expectedCallbackMethod, $cb[1] ?? null);
 
             // check expected priority
             if (str_ends_with($eventName, '.pre')) {
-                self::assertListenerAtPriority($cb, 100, $eventName, $events);
+                self::assertListenerAtPriority($cb ?? fn() => null, 100, $eventName, $events);
             } else {
-                self::assertListenerAtPriority($cb, -100, $eventName, $events);
+                self::assertListenerAtPriority($cb ?? fn() => null, -100, $eventName, $events);
             }
         }
     }

--- a/test/Storage/PluginManagerTest.php
+++ b/test/Storage/PluginManagerTest.php
@@ -11,6 +11,7 @@ use Laminas\ServiceManager\ServiceManager;
 use Laminas\ServiceManager\Test\CommonPluginManagerTrait;
 use PHPUnit\Framework\TestCase;
 
+/** @final */
 class PluginManagerTest extends TestCase
 {
     use CommonPluginManagerTrait;

--- a/test/Storage/PluginManagerTest.php
+++ b/test/Storage/PluginManagerTest.php
@@ -11,8 +11,7 @@ use Laminas\ServiceManager\ServiceManager;
 use Laminas\ServiceManager\Test\CommonPluginManagerTrait;
 use PHPUnit\Framework\TestCase;
 
-/** @final */
-class PluginManagerTest extends TestCase
+final class PluginManagerTest extends TestCase
 {
     use CommonPluginManagerTrait;
 

--- a/test/Storage/TestAsset/ClearExpiredMockAdapter.php
+++ b/test/Storage/TestAsset/ClearExpiredMockAdapter.php
@@ -10,6 +10,7 @@ use Laminas\Cache\Storage\ClearExpiredInterface;
 /**
  * @template TOptions of AdapterOptions
  * @template-extends MockAdapter<TOptions>
+ * @final
  */
 class ClearExpiredMockAdapter extends MockAdapter implements ClearExpiredInterface
 {

--- a/test/Storage/TestAsset/MockPlugin.php
+++ b/test/Storage/TestAsset/MockPlugin.php
@@ -9,8 +9,7 @@ use Laminas\Cache\Storage\Plugin\AbstractPlugin;
 use Laminas\EventManager\Event;
 use Laminas\EventManager\EventManagerInterface;
 
-/** @final */
-class MockPlugin extends AbstractPlugin
+final class MockPlugin extends AbstractPlugin
 {
     /** @var array<callable> */
     protected array $handles = [];

--- a/test/Storage/TestAsset/MockPlugin.php
+++ b/test/Storage/TestAsset/MockPlugin.php
@@ -9,6 +9,7 @@ use Laminas\Cache\Storage\Plugin\AbstractPlugin;
 use Laminas\EventManager\Event;
 use Laminas\EventManager\EventManagerInterface;
 
+/** @final */
 class MockPlugin extends AbstractPlugin
 {
     /** @var array<callable> */

--- a/test/Storage/TestAsset/OptimizableMockAdapter.php
+++ b/test/Storage/TestAsset/OptimizableMockAdapter.php
@@ -10,6 +10,7 @@ use Laminas\Cache\Storage\OptimizableInterface;
 /**
  * @template TOptions of AdapterOptions
  * @template-extends MockAdapter<TOptions>
+ * @final
  */
 class OptimizableMockAdapter extends MockAdapter implements OptimizableInterface
 {


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | yes/no
| Bugfix        | yes
| BC Break      | no




### Description
 - Remove deprecated tests functionality
 - Fix psalm issues
 - Set exceptions final
 - Add `@final` soft-final to everything else Psalm complains about

See #377 and https://github.com/laminas/laminas-serializer/pull/85
